### PR TITLE
Add crisp image rendering for canvas

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,6 +9,12 @@ body, html {
 /* 캔버스 요소의 스타일을 지정합니다 */
 #game-canvas {
     display: block; /* 캔버스 아래에 불필요한 여백이 생기는 것을 방지합니다 */
+
+    /* 이미지를 확대/축소할 때 픽셀 단위로 선명하게 유지 */
+    image-rendering: -moz-crisp-edges; /* Firefox */
+    image-rendering: -webkit-crisp-edges; /* Safari */
+    image-rendering: pixelated; /* Chrome, Edge 등 최신 브라우저 */
+    image-rendering: crisp-edges; /* 표준 */
 }
 
 /* === 아래 UI 패널 스타일을 새로 추가 === */


### PR DESCRIPTION
## Summary
- add browser-friendly `image-rendering` rules so the canvas keeps sharp edges when zoomed

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684f97634da883279000421650d48b13