### PR TITLE
Add item usage and 50/50 item spawns

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,6 +51,8 @@ window.onload = function () {
             zoomLevel: 0.5, // 줌 배율 추가 (0.25 = 4배 줌 아웃)
         };
 
+        uiManager.init(gameState);
+
         // --- 3. 게임 루프와 로직 ---
         function render() {
             if (gameState.isGameOver) return;
@@ -80,7 +82,7 @@ window.onload = function () {
             uiManager.renderHpBars(ctx, gameState.player, monsterManager.monsters);
             ctx.restore();
 
-            uiManager.updatePlayerStats(gameState);
+            uiManager.updateUI();
         }
 
         const keysPressed = {};


### PR DESCRIPTION
## Summary
- allow item pickups to spawn either gold or a potion with equal chance
- update UI manager to support using items directly from inventory
- adjust main script to initialize the UI manager and refresh UI every frame

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fdf8dfbec8327962ea473243c7c34