### PR TITLE
Fix player spawning inside walls

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Open `index.html` in a modern web browser to start the game.
 
 ### Dungeon Generation
 Each floor is carved from a depth-first search maze. Corridors span seven~10 tiles,
-and the exit is placed on a randomly chosen cell that the algorithm visited.
+and the exit is placed on a randomly chosen cell that the algorithm visited. The
+maze generator now creates more rooms and slightly wider passages so the player
+won't start trapped in a wall.
 
 ## 스킬 풀
 

--- a/main.js
+++ b/main.js
@@ -35,10 +35,11 @@ window.onload = function () {
 
         const warriorJob = { maxHp: 20, attackPower: 2 };
 
+        const startPos = mapManager.getRandomFloorPosition() || { x: mapManager.tileSize, y: mapManager.tileSize };
         const gameState = {
             player: new Player(
-                mapManager.tileSize * 1.25,
-                mapManager.tileSize * 1.25,
+                startPos.x,
+                startPos.y,
                 mapManager.tileSize,
                 warriorJob,
                 assets.player

--- a/src/map.js
+++ b/src/map.js
@@ -16,7 +16,7 @@ export class MapManager {
     }
 
     _generateMaze() {
-        const corridorWidth = 2; // <<< 통로 너비를 여기서 쉽게 조절할 수 있습니다 (2 = 2타일 너비)
+        const corridorWidth = 3; // 통로를 조금 더 넓혀 이동 공간 확보 (3타일 너비)
 
         // 1. 모든 타일을 벽으로 초기화
         const map = [];
@@ -25,9 +25,9 @@ export class MapManager {
         }
 
         // 2. 방 먼저 생성하기
-        const roomCount = 8;
-        const minRoomSize = 3;
-        const maxRoomSize = 5;
+        const roomCount = 12; // 방 개수를 늘려 보다 개방된 지형 생성
+        const minRoomSize = 4;
+        const maxRoomSize = 6;
 
         for (let i = 0; i < roomCount; i++) {
             let roomW = Math.floor(Math.random() * (maxRoomSize - minRoomSize + 1)) + minRoomSize;


### PR DESCRIPTION
## Summary
- widen corridors and make more rooms in the maze
- spawn the player on a random floor tile
- document new map generation

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ffac0ae008327a360bc68c5bc1ec9