### PR TITLE
Implement stat system with level/exp

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,26 +23,32 @@
                 <div class="stat-line">
                     <span>💪 힘:</span>
                     <span id="ui-player-strength">0</span>
+                    <button id="btn-plus-strength" class="stat-plus" style="display:none">+</button>
                 </div>
                 <div class="stat-line">
                     <span>🏃 민첩:</span>
                     <span id="ui-player-agility">0</span>
+                    <button id="btn-plus-agility" class="stat-plus" style="display:none">+</button>
                 </div>
                 <div class="stat-line">
                     <span>🛡 체력:</span>
                     <span id="ui-player-endurance">0</span>
+                    <button id="btn-plus-endurance" class="stat-plus" style="display:none">+</button>
                 </div>
                 <div class="stat-line">
                     <span>🔮 집중:</span>
                     <span id="ui-player-focus">0</span>
+                    <button id="btn-plus-focus" class="stat-plus" style="display:none">+</button>
                 </div>
                 <div class="stat-line">
                     <span>📖 지능:</span>
                     <span id="ui-player-intelligence">0</span>
+                    <button id="btn-plus-intelligence" class="stat-plus" style="display:none">+</button>
                 </div>
                 <div class="stat-line">
                     <span>👣 이동:</span>
                     <span id="ui-player-movement">0</span>
+                    <button id="btn-plus-movement" class="stat-plus" style="display:none">+</button>
                 </div>
                 <div class="stat-line">
                     <span>🚶 이동 속도:</span>

--- a/main.js
+++ b/main.js
@@ -67,6 +67,8 @@ window.onload = function() {
             }
         }
 
+        uiManager.setStatUpCallback(handleStatUp);
+
         const keysPressed = {};
         document.addEventListener('keydown', e => {
             keysPressed[e.key] = true;
@@ -110,16 +112,13 @@ window.onload = function() {
         }
 
         function checkForLevelUp() {
-            const player = gameState.player;
-            while (player.exp >= player.expNeeded) {
-                player.exp -= player.expNeeded;
-                player.level++;
-                player.expNeeded = Math.floor(player.expNeeded * 1.5);
-                player.maxHp += 5;
-                player.hp = player.maxHp;
-                player.attackPower += 1;
+            const stats = gameState.player.stats;
+            while (stats.get('exp') >= stats.get('expNeeded')) {
+                stats.levelUp();
+                stats.recalculate();
+                gameState.player.hp = gameState.player.maxHp;
                 gameState.statPoints += 5;
-                console.log(`레벨 업! LV ${player.level} 달성!`);
+                console.log(`레벨 업! LV ${stats.get('level')} 달성!`);
             }
         }
 
@@ -150,8 +149,8 @@ window.onload = function() {
                 );
 
                 if (gainedExp > 0) {
-                    player.exp += gainedExp;
-                    console.log(`${gainedExp} 경험치 획득! 현재 경험치: ${player.exp}`);
+                    player.stats.addExp(gainedExp);
+                    console.log(`${gainedExp} 경험치 획득! 현재 경험치: ${player.stats.get('exp')}`);
                     checkForLevelUp();
                 }
                 player.attackCooldown = 30;

--- a/src/entities.js
+++ b/src/entities.js
@@ -18,11 +18,6 @@ export class Player {
         this._maxHpBonus = 0;
         this._attackPowerBonus = 0;
 
-        // --- 레벨 및 경험치 속성 ---
-        this.level = 1;
-        this.exp = 0;
-        this.expNeeded = 20; // 다음 레벨까지 필요한 경험치
-
         this.attackCooldown = 0;
     }
 
@@ -51,6 +46,19 @@ export class Player {
 
     set maxHp(value) {
         this._maxHpBonus = value - this.stats.get('maxHp');
+    }
+
+    // 레벨과 경험치를 StatManager에서 조회하기 위한 게터
+    get level() {
+        return this.stats.get('level');
+    }
+
+    get exp() {
+        return this.stats.get('exp');
+    }
+
+    get expNeeded() {
+        return this.stats.get('expNeeded');
     }
 
     takeDamage(damage) {

--- a/src/managers.js
+++ b/src/managers.js
@@ -93,8 +93,31 @@ export class UIManager {
         this.expTextElement = document.getElementById('ui-exp-text');
         this.inventorySlotsElement = document.getElementById('inventory-slots');
 
+        this.plusButtons = {
+            strength: document.getElementById('btn-plus-strength'),
+            agility: document.getElementById('btn-plus-agility'),
+            endurance: document.getElementById('btn-plus-endurance'),
+            focus: document.getElementById('btn-plus-focus'),
+            intelligence: document.getElementById('btn-plus-intelligence'),
+            movement: document.getElementById('btn-plus-movement'),
+        };
+
+        this._statUpCallback = null;
+
+        for (const [stat, btn] of Object.entries(this.plusButtons)) {
+            if (btn) {
+                btn.addEventListener('click', () => {
+                    if (this._statUpCallback) this._statUpCallback(stat);
+                });
+            }
+        }
+
         // 현재 인벤토리 상태 저장용 배열 (UI 빈번한 재생성 방지)
         this._lastInventory = [];
+    }
+
+    setStatUpCallback(cb) {
+        this._statUpCallback = cb;
     }
 
     updateUI(gameState) {
@@ -122,9 +145,14 @@ export class UIManager {
         this.hpBarFillElement.style.width = `${hpRatio * 100}%`;
 
         // 경험치 바 업데이트
-        const expRatio = player.exp / player.expNeeded;
+        const expRatio = stats.get('exp') / stats.get('expNeeded');
         this.expBarFillElement.style.width = `${expRatio * 100}%`;
-        this.expTextElement.textContent = `${player.exp} / ${player.expNeeded}`;
+        this.expTextElement.textContent = `${stats.get('exp')} / ${stats.get('expNeeded')}`;
+
+        const showPlus = gameState.statPoints > 0;
+        for (const btn of Object.values(this.plusButtons)) {
+            if (btn) btn.style.display = showPlus ? 'inline' : 'none';
+        }
 
         // 인벤토리 내용이 변경된 경우에만 DOM을 갱신하여 클릭 이벤트 손실을 방지
         if (this._hasInventoryChanged(gameState.inventory)) {

--- a/src/stats.js
+++ b/src/stats.js
@@ -2,7 +2,6 @@
 
 export class StatManager {
     constructor(job) {
-        // 1. 플레이어가 직접 찍는 순수 기본 스탯
         this._baseStats = {
             strength: job.strength || 1,
             agility: job.agility || 1,
@@ -10,50 +9,51 @@ export class StatManager {
             focus: job.focus || 1,
             intelligence: job.intelligence || 1,
             movement: job.movement || 3,
+            // --- 레벨과 경험치도 기본 스탯으로 관리 ---
+            level: 1,
+            exp: 0,
+            expNeeded: 20,
         };
-
-        // 2. (나중을 위한 구멍) 장비, 버프 등으로 추가될 스탯
         this._fromEquipment = {};
         this._fromBuffs = {};
-
-        // 3. 최종 계산된 파생 스탯
         this.derivedStats = {};
-
-        this.recalculate(); // 초기 스탯 계산
+        this.recalculate();
     }
 
-    // 기본 스탯을 올리는 함수
     increaseBaseStat(stat, value) {
         if (this._baseStats[stat] !== undefined) {
             this._baseStats[stat] += value;
         }
     }
 
-    // 모든 스탯을 다시 계산하는 핵심 함수
+    // 경험치를 추가하는 전용 함수
+    addExp(amount) {
+        this._baseStats.exp += amount;
+    }
+
+    // 레벨업 처리를 위한 함수
+    levelUp() {
+        this._baseStats.level++;
+        this._baseStats.exp -= this._baseStats.expNeeded;
+        this._baseStats.expNeeded = Math.floor(this._baseStats.expNeeded * 1.5);
+        this.increaseBaseStat('endurance', 1); // 레벨업 시 체력 1 자동 증가
+        this.increaseBaseStat('strength', 1); // 레벨업 시 힘 1 자동 증가
+    }
+
     recalculate() {
         const final = { ...this._baseStats };
-        // 나중에 여기에 장비, 버프 스탯을 합산하는 로직 추가
-
-        // --- 파생 스탯 계산 ---
+        // ... (파생 스탯 계산 로직은 변경 없음)
         this.derivedStats.maxHp = 10 + final.endurance * 5;
         this.derivedStats.attackPower = 1 + final.strength * 2;
-        
-        // 무게 및 이동력 계산
         this.derivedStats.weightCapacity = 50 + final.strength * 10;
-        this.derivedStats.currentWeight = 0; // 지금은 아이템이 없어 0
-        
+        this.derivedStats.currentWeight = 0;
         const encumbranceRatio = this.derivedStats.currentWeight / this.derivedStats.weightCapacity;
-        // 무게가 가용 무게치의 50%를 넘으면 이동력 감소 시작
-        const speedModifier = Math.max(0.1, 1 - (encumbranceRatio - 0.5)); 
-        
+        const speedModifier = Math.max(0.1, 1 - (encumbranceRatio - 0.5));
         this.derivedStats.movementSpeed = final.movement * speedModifier;
-
-        // 기타 파생 스탯 (미래를 위한 구멍)
         this.derivedStats.defense = Math.floor(final.endurance / 2);
         this.derivedStats.accuracy = 75 + final.agility * 2;
     }
 
-    // 최종 계산된 스탯을 가져오는 함수
     get(statName) {
         return this.derivedStats[statName] ?? this._baseStats[statName] ?? 0;
     }

--- a/style.css
+++ b/style.css
@@ -107,6 +107,11 @@ body, html {
     color: #fff;
 }
 
+.stat-plus {
+    margin-left: 4px;
+    cursor: pointer;
+}
+
 /* ===== 인벤토리 UI 스타일 ===== */
 
 #inventory-section {


### PR DESCRIPTION
## Summary
- add level and experience tracking to `StatManager`
- update player getters to read level and experience from `StatManager`
- show [+] buttons in the UI when stat points are available
- wire up stat buttons to increase stats via `UIManager`
- adjust level-up and EXP logic to use the new stat system

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685017f1305483278da64216f54ef3d4