### PR TITLE
Restore maze layout and random spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ Open `index.html` in a modern web browser to start the game.
 
 ### Dungeon Generation
 Each floor is carved from a depth-first search maze. Corridors span seven~10 tiles,
-and the exit is placed on a randomly chosen cell that the algorithm visited. The
-maze generator now creates more rooms and slightly wider passages so the player
-won't start trapped in a wall.
+and the exit is placed on a randomly chosen cell that the algorithm visited.
 
 ## 스킬 풀
 

--- a/main.js
+++ b/main.js
@@ -40,10 +40,14 @@ window.onload = function() {
             movement: 5,
         };
 
+        const startPos = mapManager.getRandomFloorPosition() || {
+            x: mapManager.tileSize,
+            y: mapManager.tileSize,
+        };
         const gameState = {
             player: new Player(
-                mapManager.tileSize * 1.25,
-                mapManager.tileSize * 1.25,
+                startPos.x,
+                startPos.y,
                 mapManager.tileSize,
                 warriorJob,
                 assets.player

--- a/src/map.js
+++ b/src/map.js
@@ -16,7 +16,7 @@ export class MapManager {
     }
 
     _generateMaze() {
-        const corridorWidth = 3; // 통로를 조금 더 넓혀 이동 공간 확보 (3타일 너비)
+        const corridorWidth = 2; // 통로가 너무 넓어 복잡도가 떨어져 이전 너비로 복원
 
         // 1. 모든 타일을 벽으로 초기화
         const map = [];
@@ -25,9 +25,9 @@ export class MapManager {
         }
 
         // 2. 방 먼저 생성하기
-        const roomCount = 12; // 방 개수를 늘려 보다 개방된 지형 생성
-        const minRoomSize = 4;
-        const maxRoomSize = 6;
+        const roomCount = 8;
+        const minRoomSize = 3;
+        const maxRoomSize = 5;
 
         for (let i = 0; i < roomCount; i++) {
             let roomW = Math.floor(Math.random() * (maxRoomSize - minRoomSize + 1)) + minRoomSize;


### PR DESCRIPTION
## Summary
- revert maze parameters to previous tighter corridors and fewer rooms
- spawn player at a random floor position again
- update docs to remove note about wider passages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68501fd83d248327914dba83d171bdcd