### PR TITLE
Fix monster attack range and display HP bars

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -29,8 +29,8 @@ export class ChasingState {
         const dy = player.y - monster.y;
         const distance = Math.sqrt(dx * dx + dy * dy);
 
-        // 공격 범위 안에 있으면 공격
-        if (distance < monster.attackRange) {
+        // 공격 범위 안에 있으면 공격 (거리 포함)
+        if (distance <= monster.attackRange) {
             if (monster.attackCooldown === 0) {
                 onPlayerAttack(monster.attackPower);
                 monster.attackCooldown = 60; // 1초 쿨다운

--- a/src/managers.js
+++ b/src/managers.js
@@ -214,7 +214,7 @@ export class UIManager {
     }
 
     _drawHpBar(ctx, entity) {
-        if (entity.hp <= 0 || entity.hp === entity.maxHp) {
+        if (entity.hp <= 0) {
             return;
         }
         const barWidth = entity.width;


### PR DESCRIPTION
## Summary
- fix monster AI to attack when in range
- always display monster HP bars so damage is visible

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_685021d7be2883279e04a94e6e8fb861