### PR TITLE
Add groupId and strategy support

### DIFF
--- a/main.js
+++ b/main.js
@@ -50,7 +50,8 @@ window.onload = function() {
                 startPos.y,
                 mapManager.tileSize,
                 warriorJob,
-                assets.player
+                assets.player,
+                0
             ),
             inventory: [],
             gold: 0,

--- a/src/ai.js
+++ b/src/ai.js
@@ -4,7 +4,7 @@
 
 // '가만히 있는' 상태
 export class IdleState {
-    update(monster, player) {
+    update(monster, strategy, player) {
         // 플레이어가 몬스터의 시야 안에 들어오면
         const dx = player.x - monster.x;
         const dy = player.y - monster.y;
@@ -19,7 +19,7 @@ export class IdleState {
 
 // '추격하는' 상태
 export class ChasingState {
-    update(monster, player, mapManager, onPlayerAttack) {
+    update(monster, strategy, player, mapManager, onPlayerAttack) {
         // 공격 쿨다운 감소
         if (monster.attackCooldown > 0) {
             monster.attackCooldown--;

--- a/src/entities.js
+++ b/src/entities.js
@@ -4,12 +4,13 @@ import { IdleState } from './ai.js';
 import { StatManager } from './stats.js'; // StatManager를 불러옵니다.
 
 export class Player {
-    constructor(x, y, tileSize, job, image) {
+    constructor(x, y, tileSize, job, image, groupId) {
         this.x = x;
         this.y = y;
         this.width = tileSize;
         this.height = tileSize;
         this.image = image;
+        this.groupId = groupId;
 
         // --- StatManager를 생성하고 플레이어의 모든 스탯을 위임 ---
         this.stats = new StatManager(job);
@@ -75,10 +76,11 @@ export class Player {
 }
 
 export class Monster {
-    constructor(x, y, tileSize, image, sizeInTiles = {w: 1, h: 1}) {
+    constructor(x, y, tileSize, image, groupId, sizeInTiles = {w: 1, h: 1}) {
         this.id = Math.random().toString(36).substr(2, 9);
         this.x = x;
         this.y = y;
+        this.groupId = groupId;
         this.sizeInTiles = sizeInTiles;
         // 픽셀 크기 계산을 조금 더 정확하게 수정
         this.width = sizeInTiles.w * tileSize;
@@ -98,8 +100,8 @@ export class Monster {
         this.state = new IdleState();
     }
 
-    update(player, mapManager, onPlayerAttack) {
-        this.state.update(this, player, mapManager, onPlayerAttack);
+    update(strategy, player, mapManager, onPlayerAttack) {
+        this.state.update(this, strategy, player, mapManager, onPlayerAttack);
     }
 
     takeDamage(amount) {

--- a/src/managers.js
+++ b/src/managers.js
@@ -31,7 +31,7 @@ export class MonsterManager {
             }
 
             if (pos) {
-                this.monsters.push(new Monster(pos.x, pos.y, this.mapManager.tileSize, image, size));
+                this.monsters.push(new Monster(pos.x, pos.y, this.mapManager.tileSize, image, 0, size));
             }
         }
     }
@@ -60,7 +60,7 @@ export class MonsterManager {
 
     update(player, onPlayerAttack) {
         for (const monster of this.monsters) {
-            monster.update(player, this.mapManager, onPlayerAttack);
+            monster.update('aggressive', player, this.mapManager, onPlayerAttack);
         }
     }
 


### PR DESCRIPTION
## Summary
- include `groupId` for `Player` and `Monster`
- require a `strategy` argument when updating monsters
- pass default strategy in `MonsterManager`
- update AI state methods to accept the new signature
- adjust entity creation with `groupId`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68502e2662408327b518a39d19850959