### PR TITLE
Restore wider maze corridors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Open `index.html` in a modern web browser to start the game.
 
 ### Dungeon Generation
 Each floor is carved from a depth-first search maze. Corridors span seven~10 tiles,
-and the exit is placed on a randomly chosen cell that the algorithm visited.
+and the exit is placed on a randomly chosen cell that the algorithm visited. The
+maze generator now creates more rooms and slightly wider passages so the player
+won't start trapped in a wall.
 
 ## 스킬 풀
 

--- a/src/map.js
+++ b/src/map.js
@@ -16,7 +16,7 @@ export class MapManager {
     }
 
     _generateMaze() {
-        const corridorWidth = 2; // 통로가 너무 넓어 복잡도가 떨어져 이전 너비로 복원
+        const corridorWidth = 3; // 통로를 조금 더 넓혀 이동 공간 확보 (3타일 너비)
 
         // 1. 모든 타일을 벽으로 초기화
         const map = [];
@@ -25,9 +25,9 @@ export class MapManager {
         }
 
         // 2. 방 먼저 생성하기
-        const roomCount = 8;
-        const minRoomSize = 3;
-        const maxRoomSize = 5;
+        const roomCount = 12; // 방 개수를 늘려 보다 개방된 지형 생성
+        const minRoomSize = 4;
+        const maxRoomSize = 6;
 
         for (let i = 0; i < roomCount; i++) {
             let roomW = Math.floor(Math.random() * (maxRoomSize - minRoomSize + 1)) + minRoomSize;


### PR DESCRIPTION
## Summary
- widen maze corridors to 3 tiles and use bigger rooms
- document the wider passages in README

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_685038298b5883278f320345c6cf53b7