### PR TITLE
Add archetype AI and warrior mercenary

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,9 @@
                 <div id="inventory-slots">
                 </div>
             </div>
+            <div id="mercenary-controls">
+                <button id="btn-hire-warrior" class="hire-button">⚔️ 전사 고용 (50💰)</button>
+            </div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -147,6 +147,16 @@ body, html {
     height: 100%;
 }
 
+#mercenary-controls {
+    margin-top: 10px;
+}
+
+.hire-button {
+    width: 100%;
+    padding: 4px 0;
+    margin-top: 5px;
+}
+
 /* 경험치 바 스타일 */
 .exp-bar-container {
     width: 100%;


### PR DESCRIPTION
## Summary
- revamp `src/ai.js` to use archetype-style AI with `MeleeAI`
- extend entity classes with friendliness flags
- add `Mercenary` class for recruitable warriors
- update AI manager to feed context objects
- allow hiring a warrior ally and render allies
- style hire button in UI

## Testing
- `node --check src/ai.js`
- `node --check src/entities.js`
- `node --check src/ai-managers.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_685047bc16c48327a271446428b1404b