### PR TITLE
Fix speed initialization for Player

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -12,11 +12,17 @@ class Entity {
         this.width = tileSize;
         this.height = tileSize;
         this.image = image;
-        this.speed = 4; // 기본 이동 속도 통일
+        this._speed = 4; // 기본 이동 속도 통일
         this.attackCooldown = 0;
         this.hp = 1; this.maxHp = 1;
         this.isPlayer = false;
         this.isFriendly = false;
+    }
+    get speed() {
+        return this._speed;
+    }
+    set speed(value) {
+        this._speed = value;
     }
     render(ctx) {
         if (this.image) {


### PR DESCRIPTION
## Summary
- avoid calling Player speed setter before stats exist
- add basic speed getter/setter to Entity

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6850534ba8bc83278f22ae45d81e3762