### PR TITLE
Refactor entities to use StatManager configs

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,9 +60,9 @@ window.onload = function() {
                 startPos.x,
                 startPos.y,
                 mapManager.tileSize,
-                warriorJob,
                 assets.player,
-                playerGroup.id
+                playerGroup.id,
+                warriorJob
             ),
             inventory: [],
             allies: [],

--- a/src/managers.js
+++ b/src/managers.js
@@ -31,7 +31,16 @@ export class MonsterManager {
             }
 
             if (pos) {
-                this.monsters.push(new Monster(pos.x, pos.y, this.mapManager.tileSize, image, 0, size));
+                const config = {
+                    sizeInTiles_w: size.w,
+                    sizeInTiles_h: size.h,
+                    strength: size.w > 1 ? 2 : 1,
+                    endurance: size.w > 1 ? 2 : 0,
+                    visionRange: 192 * 5,
+                    attackRange: 192,
+                    expValue: size.w > 1 ? 15 : 5
+                };
+                this.monsters.push(new Monster(pos.x, pos.y, this.mapManager.tileSize, image, 0, config));
             }
         }
     }
@@ -79,7 +88,15 @@ export class MercenaryManager {
     }
 
     hireMercenary(x, y, tileSize, groupId) {
-        const newMerc = new Mercenary(x, y, tileSize, this.assets.mercenary, groupId);
+        const job = {
+            strength: 2,
+            agility: 2,
+            endurance: 2,
+            movement: 4,
+            visionRange: 192 * 4,
+            attackRange: 192 * 0.8
+        };
+        const newMerc = new Mercenary(x, y, tileSize, this.assets.mercenary, groupId, job);
         this.mercenaries.push(newMerc);
         return newMerc;
     }

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,19 +1,22 @@
 // src/stats.js
 
 export class StatManager {
-    constructor(config) {
+    constructor(config = {}) {
         // 1. 유닛의 기본 스탯 (직업, 몬스터 종류 등에 따라 결정)
-        this._baseStats = {
-            level: config.level || 1,
-            exp: config.exp || 0,
-            expNeeded: config.expNeeded || 20,
-            strength: config.strength || 1,
-            agility: config.agility || 1,
-            endurance: config.endurance || 1,
-            focus: config.focus || 1,
-            intelligence: config.intelligence || 1,
-            movement: config.movement || 3,
+        const defaults = {
+            level: 1,
+            exp: 0,
+            expNeeded: 20,
+            strength: 1,
+            agility: 1,
+            endurance: 1,
+            focus: 1,
+            intelligence: 1,
+            movement: 3,
         };
+
+        // config 객체에 추가로 전달된 값은 그대로 저장하여 활용할 수 있도록 한다
+        this._baseStats = { ...defaults, ...config };
         // 2. 플레이어가 직접 투자한 스탯
         this._pointsAllocated = {
             strength: 0, agility: 0, endurance: 0, focus: 0, intelligence: 0


### PR DESCRIPTION
## Summary
- refactor `Entity` so `StatManager` is created by the base class
- allow dynamic stat configuration in `StatManager`
- spawn monsters with stat configs
- give mercenaries default stat config
- update player creation to new constructor

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68505a06c260832790eab134e1968c6d