### PR TITLE
Bug fixes for level up and potion pickup

### DIFF
--- a/main.js
+++ b/main.js
@@ -136,14 +136,11 @@ window.onload = function() {
                 if (itemToPick.name === 'gold') {
                     gameState.gold += 10; // 예시: 골드 10씩 증가
                     console.log(`골드를 주웠습니다! 현재 골드: ${gameState.gold}`);
-                } else if (itemToPick.name === 'potion') {
-                    player.hp = Math.min(player.stats.get('maxHp'), player.hp + 5);
-                    console.log(`포션을 주워 바로 사용했습니다! HP +5`);
+                } else {
+                    // 포션을 포함한 다른 아이템은 인벤토리에 저장
+                    gameState.inventory.push(itemToPick);
+                    console.log(`${itemToPick.name}을(를) 인벤토리에 추가했습니다.`);
                 }
-                // 다른 아이템은 추후에 여기에 추가할 수 있습니다.
-                // else {
-                //    gameState.inventory.push(itemToPick); // 골드, 포션 외 다른 아이템은 인벤토리에 추가
-                // }
 
                 itemManager.removeItem(itemToPick); // 맵에서 아이템 제거
             }

--- a/src/stats.js
+++ b/src/stats.js
@@ -56,13 +56,16 @@ export class StatManager {
     }
 
     addExp(amount) {
-        this.derivedStats.exp += amount;
+        // 경험치는 기본 스탯에 누적한 뒤 즉시 재계산하여 UI와 레벨업 체크에 반영
+        this._baseStats.exp += amount;
+        this.recalculate();
     }
 
     levelUp() {
-        this.derivedStats.level++;
-        this.derivedStats.exp -= this.derivedStats.expNeeded;
-        this.derivedStats.expNeeded = Math.floor(this.derivedStats.expNeeded * 1.5);
+        // 레벨 관련 수치를 기본 스탯에 반영해 recalculate 이후에도 유지한다
+        this._baseStats.level++;
+        this._baseStats.exp -= this._baseStats.expNeeded;
+        this._baseStats.expNeeded = Math.floor(this._baseStats.expNeeded * 1.5);
         // 레벨업 시 기본 스탯 상승 (예시: 체력, 힘)
         this.increaseBaseStat('endurance', 1);
         this.increaseBaseStat('strength', 1);


### PR DESCRIPTION
## Summary
- ensure experience and levels persist by updating base stats
- store potions in the inventory instead of using them immediately

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68507681cc248327bdd76b38fb1aa798