### PR TITLE
Implement event-driven architecture

### DIFF
--- a/src/eventManager.js
+++ b/src/eventManager.js
@@ -1,3 +1,4 @@
+// src/eventManager.js
 export class EventManager {
     constructor() {
         this.listeners = {};
@@ -10,7 +11,13 @@ export class EventManager {
     }
     publish(eventName, data) {
         if (this.listeners[eventName]) {
-            this.listeners[eventName].forEach(callback => callback(data));
+            this.listeners[eventName].forEach(callback => {
+                try {
+                    callback(data);
+                } catch (error) {
+                    console.error(`Error in event listener for ${eventName}:`, error);
+                }
+            });
         }
     }
 }

--- a/src/logManager.js
+++ b/src/logManager.js
@@ -1,17 +1,40 @@
+// src/logManager.js
 export class LogManager {
-    constructor() {
+    constructor(eventManager) {
         this.logElement = document.getElementById('combat-log-content');
         this.logs = [];
+
+        eventManager.subscribe('log', (data) => this.add(data.message));
+
+        eventManager.subscribe('entity_attack', (data) => {
+            const { attacker, defender, damage } = data;
+            this.add(`${attacker.constructor.name} (이)가 ${defender.constructor.name} (을)를 공격하여 ${damage}의 피해를 입혔습니다.`);
+        });
+
+        eventManager.subscribe('entity_death', (data) => {
+            const { victim } = data;
+            this.add(`%c${victim.constructor.name} (이)가 쓰러졌습니다.`, 'red');
+        });
+
+        eventManager.subscribe('exp_gained', (data) => {
+            this.add(`%c${data.exp}의 경험치를 획득했습니다.`, 'yellow');
+        });
+
+        eventManager.subscribe('level_up', (data) => {
+            this.add(`%c레벨 업! LV ${data.level} 달성!`, 'cyan');
+        });
     }
-    add(message) {
-        this.logs.push(message);
-        if (this.logs.length > 20) {
-            this.logs.shift();
-        }
+
+    add(message, color = 'white') {
+        this.logs.push({ message, color });
+        if (this.logs.length > 20) this.logs.shift();
         this.render();
     }
+
     render() {
-        this.logElement.innerHTML = this.logs.join('<br>');
+        this.logElement.innerHTML = this.logs.map(log =>
+            `<span style="color: ${log.color};">${log.message}</span>`
+        ).join('<br>');
         this.logElement.scrollTop = this.logElement.scrollHeight;
     }
 }

--- a/src/managers.js
+++ b/src/managers.js
@@ -49,14 +49,15 @@ export class MonsterManager {
         const monster = this.monsters.find(m => m.id === monsterId);
         if (monster) {
             monster.takeDamage(damage);
-            if (monster.hp <= 0) {
-                const exp = monster.expValue;
-                const name = monster.constructor.name;
-                this.monsters = this.monsters.filter(m => m.id !== monsterId);
-                return { gainedExp: exp, victimName: name };
-            }
+            // 죽었는지 여부만 반환
+            return monster.hp <= 0 ? { wasKilled: true, victim: monster } : { wasKilled: false };
         }
-        return { gainedExp: 0, victimName: null };
+        return { wasKilled: false };
+    }
+
+    // 이벤트 매니저가 "이 몬스터 제거해"라고 알려주면, 그때 제거만 함
+    removeMonster(monsterId) {
+        this.monsters = this.monsters.filter(m => m.id !== monsterId);
     }
 
     getMonsterAt(x, y) {
@@ -246,7 +247,7 @@ export class UIManager {
 
     // HP 바를 그리는 메서드 (이전과 동일)
     renderHpBars(ctx, player, monsters, mercenaries) {
-        // this._drawHpBar(ctx, player); // 플레이어 HP바는 이제 HTML UI로 옮겼으므로 주석 처리
+        // 플레이어 HP바는 이제 여기서 그리지 않음 (HTML로 완전히 이전)
         for (const monster of monsters) {
             this._drawHpBar(ctx, monster);
         }
@@ -256,9 +257,7 @@ export class UIManager {
     }
 
     _drawHpBar(ctx, entity) {
-        if (entity.hp >= entity.maxHp || entity.hp <= 0) {
-            return;
-        }
+        if (entity.hp >= entity.maxHp || entity.hp <= 0) return;
         const barWidth = entity.width;
         const barHeight = 8;
         const x = entity.x;


### PR DESCRIPTION
## Summary
- add error-safe EventManager
- update LogManager to log via events
- adjust MonsterManager responsibilities
- allow MetaAIManager to remove dead units and emit attacks
- restructure main.js to wire up events

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685127532dec83278bd7e8d566aa0233