### PR TITLE
Implement monster death workflow

### DIFF
--- a/src/ai-managers.js
+++ b/src/ai-managers.js
@@ -21,11 +21,10 @@ class AIGroup {
 export class MetaAIManager {
     constructor(eventManager) {
         this.groups = {};
-        // entity_death 이벤트를 구독하여, 그룹에서 해당 멤버를 제거
-        eventManager.subscribe('entity_death', (data) => {
-            const victim = data.victim;
-            if (this.groups[victim.groupId]) {
-                this.groups[victim.groupId].removeMember(victim.id);
+        // "몬스터 제거" 이벤트를 구독하여 그룹에서 멤버를 제거
+        eventManager.subscribe('entity_removed', (data) => {
+            for (const groupId in this.groups) {
+                this.groups[groupId].removeMember(data.victimId);
             }
         });
     }

--- a/src/managers.js
+++ b/src/managers.js
@@ -4,11 +4,17 @@ import { Monster, Item, Mercenary } from './entities.js'; // Mercenary 추가
 import { MetaAIManager as BaseMetaAI } from './ai-managers.js'; // 이름 충돌 방지
 
 export class MonsterManager {
-    constructor(monsterCount, mapManager, assets) {
+    constructor(monsterCount, mapManager, assets, eventManager) {
         this.monsters = [];
         this.mapManager = mapManager;
         this.assets = assets;
         this._spawnMonsters(monsterCount);
+        // "몬스터 제거" 이벤트를 구독
+        eventManager.subscribe('entity_removed', (data) => {
+            if (this.monsters.some(m => m.id === data.victimId)) {
+                this.removeMonster(data.victimId);
+            }
+        });
     }
 
     _spawnMonsters(count) {

--- a/src/workflows.js
+++ b/src/workflows.js
@@ -1,0 +1,21 @@
+// src/workflows.js
+
+// === 몬스터 사망 워크플로우 ('코드 1') ===
+export function monsterDeathWorkflow(context) {
+    const { eventManager, victim, attacker } = context;
+
+    // 1. "몬스터 사망!" 이벤트를 방송한다.
+    eventManager.publish('entity_death', { victim, attacker });
+
+    // 2. "경험치 획득!" 이벤트를 방송한다.
+    if (!victim.isFriendly && (attacker.isPlayer || attacker.isFriendly)) {
+        const exp = victim.expValue;
+        eventManager.publish('exp_gained', { player: attacker, exp });
+    }
+    
+    // 3. (미래를 위한 구멍) "아이템 드랍!" 이벤트를 방송한다.
+    eventManager.publish('drop_loot', { position: { x: victim.x, y: victim.y }, monsterType: victim.constructor.name });
+    
+    // 4. 사망한 몬스터를 모든 매니저에서 확실하게 제거한다.
+    eventManager.publish('entity_removed', { victimId: victim.id });
+}


### PR DESCRIPTION
## Summary
- introduce `monsterDeathWorkflow` for consistent death handling
- subscribe to `entity_removed` events in `MonsterManager` and `MetaAIManager`
- call death workflow from attack resolution and log related events

## Testing
- `node --check main.js`
- `node --check src/ai-managers.js`
- `node --check src/managers.js`

------
https://chatgpt.com/codex/tasks/task_e_68512da29de883278f73965a03bb63af