### PR TITLE
Implement snapshot-based SaveLoad system

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
             </div>
             <div id="mercenary-controls">
                 <button id="hire-mercenary">전사 용병 고용 (50골드)</button>
+                <button id="save-game-btn">게임 저장</button>
             </div>
         </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ import { MercenaryManager, MonsterManager, UIManager, ItemManager } from './src/
 import { Player } from './src/entities.js';
 import { AssetLoader } from './src/assetLoader.js';
 import { MetaAIManager, STRATEGY } from './src/ai-managers.js';
+import { SaveLoadManager } from './src/saveLoadManager.js';
 
 window.onload = function() {
     const loader = new AssetLoader();
@@ -42,6 +43,7 @@ window.onload = function() {
         const itemManager = new ItemManager(20, mapManager, assets);
         const uiManager = new UIManager();
         const metaAIManager = new MetaAIManager(eventManager);
+        const saveLoadManager = new SaveLoadManager();
 
         const playerGroup = metaAIManager.createGroup('player_party', STRATEGY.AGGRESSIVE);
         const monsterGroup = metaAIManager.createGroup('dungeon_monsters', STRATEGY.AGGRESSIVE);
@@ -73,6 +75,13 @@ window.onload = function() {
                 const newMerc = mercenaryManager.hireMercenary(gameState.player.x, gameState.player.y, mapManager.tileSize, playerGroup.id);
                 playerGroup.addMember(newMerc);
             }
+        };
+
+        document.getElementById('save-game-btn').onclick = () => {
+            const saveData = saveLoadManager.gatherSaveData(gameState, monsterManager, mercenaryManager);
+            console.log("--- GAME STATE SAVED (SNAPSHOT) ---");
+            console.log(saveData);
+            eventManager.publish('log', { message: '게임 상태 스냅샷이 콘솔에 저장되었습니다.' });
         };
 
         // === 2. 이벤트 구독 설정 (워크플로우 기반) ===

--- a/src/entities.js
+++ b/src/entities.js
@@ -27,7 +27,23 @@ class Entity {
     get visionRange() { return this.stats.get('visionRange'); }
     get attackRange() { return this.stats.get('attackRange'); }
 
-    render(ctx) { if (this.image) { ctx.drawImage(this.image, this.x, this.y, this.width, this.height); } }
+    render(ctx) {
+        if (this.image) {
+            ctx.drawImage(this.image, this.x, this.y, this.width, this.height);
+        }
+    }
+
+    getSaveState() {
+        return {
+            id: this.id,
+            type: this.constructor.name,
+            x: this.x,
+            y: this.y,
+            hp: this.hp,
+            stats: this.stats.getSavableState(), // StatManager에게 상태 보고를 위임
+        };
+    }
+
     takeDamage(damage) { this.hp -= damage; if(this.hp < 0) this.hp = 0; }
 }
 
@@ -71,5 +87,13 @@ export class Item {
         if (this.image) {
             ctx.drawImage(this.image, this.x, this.y, this.width, this.height);
         }
+    }
+
+    getSaveState() {
+        return {
+            name: this.name,
+            x: this.x,
+            y: this.y,
+        };
     }
 }

--- a/src/saveLoadManager.js
+++ b/src/saveLoadManager.js
@@ -1,0 +1,20 @@
+export class SaveLoadManager {
+    // 게임의 현재 상태를 하나의 객체로 수집 (스냅샷 찍기)
+    gatherSaveData(gameState, monsterManager, mercenaryManager) {
+        const saveData = {
+            timestamp: new Date().toISOString(),
+            player: gameState.player.getSaveState(),
+            gold: gameState.gold,
+            statPoints: gameState.statPoints,
+            inventory: gameState.inventory.map(item => item.name), // 아이템은 이름만 저장
+            monsters: monsterManager.monsters.map(m => m.getSaveState()),
+            mercenaries: mercenaryManager.mercenaries.map(m => m.getSaveState()),
+        };
+        return saveData;
+    }
+
+    // (미래를 위한 구멍) 저장된 데이터로 게임 상태를 복원하는 함수
+    loadGameFromData(saveData, gameState, ...allManagers) {
+        console.log("게임 불러오기 기능은 여기에 구현될 예정입니다.");
+    }
+}

--- a/src/stats.js
+++ b/src/stats.js
@@ -55,6 +55,13 @@ export class StatManager {
         return this.derivedStats[statName] ?? 0;
     }
 
+    getSavableState() {
+        return {
+            baseStats: this._baseStats,
+            pointsAllocated: this._pointsAllocated,
+        };
+    }
+
     addExp(amount) {
         // 경험치는 기본 스탯에 누적한 뒤 즉시 재계산하여 UI와 레벨업 체크에 반영
         this._baseStats.exp += amount;


### PR DESCRIPTION
## Summary
- implement a new `SaveLoadManager` for collecting game state snapshots
- expose `getSaveState` in `Entity` and `Item` classes
- expose `getSavableState` in `StatManager`
- add "게임 저장" button to the UI
- wire SaveLoadManager into the main game loop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685132a2cd0c8327b9f3300dc2b92ba7