### PR TITLE
Apply stabilization fixes to logs and stats

### DIFF
--- a/src/logManager.js
+++ b/src/logManager.js
@@ -37,7 +37,9 @@ export class CombatLogManager {
         this.logElement.innerHTML = this.logs.map(log =>
             `<span style="color: ${log.color};">${log.message}</span>`
         ).join('<br>');
-        this.logElement.scrollTop = this.logElement.scrollHeight;
+        setTimeout(() => {
+            this.logElement.scrollTop = this.logElement.scrollHeight;
+        }, 0);
     }
 }
 
@@ -69,7 +71,9 @@ export class SystemLogManager {
     render() {
         if (this.logElement) {
             this.logElement.innerText = this.logs.join('\n');
-            this.logElement.scrollTop = this.logElement.scrollHeight;
+            setTimeout(() => {
+                this.logElement.scrollTop = this.logElement.scrollHeight;
+            }, 0);
         }
     }
 }

--- a/src/stats.js
+++ b/src/stats.js
@@ -33,24 +33,24 @@ export class StatManager {
     }
 
     recalculate() {
+        const currentExp = this.derivedStats.exp;
+        const currentLevel = this.derivedStats.level;
+        const currentExpNeeded = this.derivedStats.expNeeded;
+
         const final = {};
-        // 기본 스탯과 포인트 투자 스탯을 합산
         for (const stat in this._baseStats) {
             final[stat] = (this._baseStats[stat] || 0) + (this._pointsAllocated[stat] || 0);
         }
 
-        // 파생 스탯 계산
         final.maxHp = 10 + final.endurance * 5;
         final.attackPower = 1 + final.strength * 2;
         final.movementSpeed = final.movement;
 
-        // 기존의 level, exp, expNeeded 값을 유지 (버그 수정)
-        // 이전에 계산된 값이 있다면 그것을 사용하고, 없다면 final에서 가져옴
-        final.level = this.derivedStats.level || final.level;
-        final.exp = this.derivedStats.exp || final.exp;
-        final.expNeeded = this.derivedStats.expNeeded || final.expNeeded;
-
         this.derivedStats = final;
+
+        if (currentExp !== undefined) this.derivedStats.exp = currentExp;
+        if (currentLevel !== undefined) this.derivedStats.level = currentLevel;
+        if (currentExpNeeded !== undefined) this.derivedStats.expNeeded = currentExpNeeded;
     }
 
     get(statName) {

--- a/style.css
+++ b/style.css
@@ -13,6 +13,11 @@ body, html {
     image-rendering: -webkit-crisp-edges;
     image-rendering: pixelated;
     image-rendering: crisp-edges;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: -1;
+    pointer-events: none;
 }
 
 /* === UI \ud328\ub110 \uc2a4\ud0c0\uc77c \uc804\uccb4 \uc218\uc815 \ubc0f \ucd94\uac00 === */
@@ -38,6 +43,7 @@ body, html {
     font-family: sans-serif;
     font-weight: bold;
     box-shadow: 0 0 10px rgba(0,0,0,0.5);
+    pointer-events: auto;
 }
 
 #ui-panel h2 {
@@ -203,6 +209,7 @@ body, html {
     font-size: 12px;
     padding: 10px;
     overflow-y: auto;
+    pointer-events: auto;
 }
 
 /* style.css 파일 맨 아래에 추가 */
@@ -230,6 +237,7 @@ body, html {
     padding: 10px;
     overflow-y: auto;
     opacity: 0.7; /* 약간 투명하게 */
+    pointer-events: auto;
 }
 
 #system-log-content {


### PR DESCRIPTION
## Summary
- let the game canvas ignore pointer events and fix z-index
- ensure combat and system logs auto-scroll correctly
- preserve EXP-related values when recalculating stats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685155ec2ecc83279f292bd6f2b02dc8