### PR TITLE
Fix experience gain and log flooding

### DIFF
--- a/main.js
+++ b/main.js
@@ -190,7 +190,7 @@ window.onload = function() {
 
         function update() {
             if (gameState.isGameOver) return;
-            eventManager.publish('debug', { tag: 'System', message: '--- Frame Update Start ---' });
+            eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update Start ---' });
             const player = gameState.player;
             if (player.attackCooldown > 0) player.attackCooldown--;
             let moveX = 0, moveY = 0;
@@ -231,7 +231,7 @@ window.onload = function() {
             }
             const context = { eventManager, player, mapManager, monsterManager, mercenaryManager };
             metaAIManager.update(context);
-            eventManager.publish('debug', { tag: 'System', message: '--- Frame Update End ---' });
+            eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update End ---' });
         }
 
         function checkForLevelUp(player) {

--- a/src/logManager.js
+++ b/src/logManager.js
@@ -34,12 +34,15 @@ export class CombatLogManager {
     }
 
     render() {
+        const isAtBottom = Math.abs(this.logElement.scrollHeight - this.logElement.clientHeight - this.logElement.scrollTop) < 5;
         this.logElement.innerHTML = this.logs.map(log =>
             `<span style="color: ${log.color};">${log.message}</span>`
         ).join('<br>');
-        setTimeout(() => {
-            this.logElement.scrollTop = this.logElement.scrollHeight;
-        }, 0);
+        if (isAtBottom) {
+            setTimeout(() => {
+                this.logElement.scrollTop = this.logElement.scrollHeight;
+            }, 0);
+        }
     }
 }
 
@@ -64,16 +67,29 @@ export class SystemLogManager {
     }
     add(tag, message) {
         const timestamp = new Date().toLocaleTimeString();
-        this.logs.push(`[${timestamp}] [${tag}] ${message}`);
-        if (this.logs.length > 50) this.logs.shift();
+
+        const last = this.logs[this.logs.length - 1];
+        if (last && last.tag === tag && last.message === message) {
+            last.count = (last.count || 1) + 1;
+        } else {
+            this.logs.push({ timestamp, tag, message, count: 1 });
+            if (this.logs.length > 50) this.logs.shift();
+        }
         this.render();
     }
     render() {
         if (this.logElement) {
-            this.logElement.innerText = this.logs.join('\n');
-            setTimeout(() => {
-                this.logElement.scrollTop = this.logElement.scrollHeight;
-            }, 0);
+            const isAtBottom = Math.abs(this.logElement.scrollHeight - this.logElement.clientHeight - this.logElement.scrollTop) < 5;
+            const text = this.logs.map(log => {
+                const countText = log.count > 1 ? ` (x${log.count})` : '';
+                return `[${log.timestamp}] [${log.tag}] ${log.message}${countText}`;
+            }).join('\n');
+            this.logElement.innerText = text;
+            if (isAtBottom) {
+                setTimeout(() => {
+                    this.logElement.scrollTop = this.logElement.scrollHeight;
+                }, 0);
+            }
         }
     }
 }

--- a/src/stats.js
+++ b/src/stats.js
@@ -33,10 +33,6 @@ export class StatManager {
     }
 
     recalculate() {
-        const currentExp = this.derivedStats.exp;
-        const currentLevel = this.derivedStats.level;
-        const currentExpNeeded = this.derivedStats.expNeeded;
-
         const final = {};
         for (const stat in this._baseStats) {
             final[stat] = (this._baseStats[stat] || 0) + (this._pointsAllocated[stat] || 0);
@@ -47,10 +43,6 @@ export class StatManager {
         final.movementSpeed = final.movement;
 
         this.derivedStats = final;
-
-        if (currentExp !== undefined) this.derivedStats.exp = currentExp;
-        if (currentLevel !== undefined) this.derivedStats.level = currentLevel;
-        if (currentExpNeeded !== undefined) this.derivedStats.expNeeded = currentExpNeeded;
     }
 
     get(statName) {


### PR DESCRIPTION
## Summary
- ensure `StatManager.recalculate` keeps updated experience values
- keep user scroll position when rendering logs
- combine duplicate system logs and throttle frame update logging

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68515d5eb8088327a73dde030ceb8c5e