### PR TITLE
Fix damage calculation event flow

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -1,5 +1,14 @@
 export class CombatCalculator {
-    calculateDamage(attacker, defender) {
-        return attacker.attackPower;
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+    }
+
+    // 공격 이벤트를 처리하여 피해량을 계산한 뒤 이벤트로 발행한다.
+    handleAttack(data) {
+        const { attacker, defender } = data;
+        const damage = attacker.attackPower; // 지금은 간단한 계산
+
+        // 계산된 피해량을 포함하여 이벤트를 발행한다.
+        this.eventManager.publish('damage_calculated', { ...data, damage });
     }
 }

--- a/src/logManager.js
+++ b/src/logManager.js
@@ -8,9 +8,10 @@ export class CombatLogManager {
 
         eventManager.subscribe('log', (data) => this.add(data.message));
 
-        eventManager.subscribe('entity_attack', (data) => {
+        // 'damage_calculated' 이벤트를 구독하여 전투 로그를 남긴다.
+        eventManager.subscribe('damage_calculated', (data) => {
             const { attacker, defender, damage } = data;
-            this.add(`${attacker.constructor.name} (이)가 ${defender.constructor.name} (을)를 공격하여 ${damage}의 피해를 입혔습니다.`);
+            this.add(`${attacker.constructor.name}가 ${defender.constructor.name}을(를) 공격하여 ${damage}의 피해를 입혔습니다.`);
         });
 
         eventManager.subscribe('entity_death', (data) => {


### PR DESCRIPTION
## Summary
- let `CombatCalculator` publish a `damage_calculated` event
- log damage using the new event
- update main event flow to handle damage_calculated and entity_death

## Testing
- `node --check main.js`
- `node --check src/combat.js`
- `node --check src/logManager.js`


------
https://chatgpt.com/codex/tasks/task_e_6851602c41b083278d437874d18af503