### PR TITLE
Fix monster death removal and EXP gain

### DIFF
--- a/main.js
+++ b/main.js
@@ -124,6 +124,7 @@ window.onload = function() {
             data.defender.takeDamage(data.damage);
             if (data.defender.hp <= 0) {
                 eventManager.publish('entity_death', { attacker: data.attacker, victim: data.defender });
+                eventManager.publish('entity_removed', { victimId: data.defender.id });
             }
         });
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -22,6 +22,9 @@ export class CharacterFactory {
 
         // 2. 기본 스탯 설정 (직업, 몬스터 종류, 출신 보너스 등)
         const baseStats = { ...(config.baseStats || {}) };
+        if (type === 'monster' && baseStats.expValue === undefined) {
+            baseStats.expValue = 5;
+        }
         const originBonus = ORIGINS[originId].stat_bonuses;
         for (const stat in originBonus) {
             baseStats[stat] = (baseStats[stat] || 0) + originBonus[stat];


### PR DESCRIPTION
## Summary
- remove monsters when they die
- give monsters default `expValue` so EXP is gained on kill

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851762f075c8327856702c507022cb5