### PR TITLE
Add item and equipment system

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,11 @@
 // main.js
 
-import { CharacterFactory } from './src/factory.js';
+import { CharacterFactory, ItemFactory } from './src/factory.js';
 import { EventManager } from './src/eventManager.js';
 import { CombatLogManager, SystemLogManager } from './src/logManager.js';
 import { CombatCalculator } from './src/combat.js';
 import { MapManager } from './src/map.js';
-import { MercenaryManager, MonsterManager, UIManager, ItemManager } from './src/managers.js';
+import { MercenaryManager, MonsterManager, UIManager, ItemManager, EquipmentManager } from './src/managers.js';
 import { AssetLoader } from './src/assetLoader.js';
 import { MetaAIManager, STRATEGY } from './src/ai-managers.js';
 import { SaveLoadManager } from './src/saveLoadManager.js';
@@ -23,6 +23,9 @@ window.onload = function() {
     loader.loadImage('wall', 'assets/wall.png');
     loader.loadImage('gold', 'assets/gold.png');
     loader.loadImage('potion', 'assets/potion.png');
+    loader.loadImage('sword', 'assets/images/shortsword.png');
+    loader.loadImage('bow', 'assets/images/bow.png');
+    loader.loadImage('leather_armor', 'assets/images/leatherarmor.png');
 
     loader.onReady(assets => {
         const layerManager = new LayerManager();
@@ -31,6 +34,14 @@ window.onload = function() {
         // === 1. 핵심 객체들 생성 ===
         const eventManager = new EventManager();
         const factory = new CharacterFactory(assets);
+        const itemFactory = new ItemFactory(assets);
+        const equipmentManager = new EquipmentManager(eventManager);
+        ItemManager.prototype._spawnItems = function(count) {
+            for(let i=0; i<count; i++) {
+                const pos = this.mapManager.getRandomFloorPosition();
+                this.items.push(itemFactory.create('short_sword', pos.x, pos.y, this.mapManager.tileSize));
+            }
+        };
         const combatLogManager = new CombatLogManager(eventManager);
         const systemLogManager = new SystemLogManager(eventManager);
         const combatCalculator = new CombatCalculator(eventManager);
@@ -41,6 +52,14 @@ window.onload = function() {
         const mercenaryManager = new MercenaryManager(assets);
         const itemManager = new ItemManager(20, mapManager, assets);
         const uiManager = new UIManager();
+        uiManager.useItem = function(itemIndex, gameState) {
+            const item = gameState.inventory[itemIndex];
+            if (item.type === 'weapon' || item.type === 'armor') {
+                equipmentManager.equip(gameState.player, item);
+                gameState.inventory.splice(itemIndex, 1);
+                return;
+            }
+        };
         const metaAIManager = new MetaAIManager(eventManager);
         const saveLoadManager = new SaveLoadManager();
 

--- a/src/data/affixes.js
+++ b/src/data/affixes.js
@@ -1,0 +1,9 @@
+export const PREFIXES = {
+    sharp: { name: '날카로운', stats: { attackPower: 2 } },
+    sturdy: { name: '견고한', stats: { maxHp: 5 } },
+};
+
+export const SUFFIXES = {
+    of_strength: { name: '힘의', stats: { strength: 1 } },
+    of_agility: { name: '민첩의', stats: { agility: 1 } },
+};

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -1,0 +1,8 @@
+export const ITEMS = {
+    // 무기
+    short_sword: { name: '단검', type: 'weapon', tags: ['melee', 'sword'], imageKey: 'sword' },
+    long_bow: { name: '장궁', type: 'weapon', tags: ['ranged', 'bow'], imageKey: 'bow' },
+
+    // 방어구
+    leather_armor: { name: '가죽 갑옷', type: 'armor', tags: ['armor', 'light_armor'], imageKey: 'leather_armor' },
+};

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,6 +1,6 @@
 // src/entities.js
 
-import { MeleeAI } from './ai.js';
+import { MeleeAI, RangedAI } from './ai.js';
 import { StatManager } from './stats.js';
 
 class Entity {
@@ -21,6 +21,14 @@ class Entity {
         this.isPlayer = false;
         this.isFriendly = false;
         this.ai = null;
+
+        // --- 장비창(Equipment) 추가 ---
+        this.equipment = {
+            weapon: null,
+            armor: null,
+            accessory1: null,
+            accessory2: null,
+        };
     }
 
     get speed() { return this.stats.get('movementSpeed'); }
@@ -29,6 +37,18 @@ class Entity {
     get expValue() { return this.stats.get('expValue'); }
     get visionRange() { return this.stats.get('visionRange'); }
     get attackRange() { return this.stats.get('attackRange'); }
+
+    // --- AI를 동적으로 변경하는 메서드 추가 ---
+    updateAI() {
+        if (!this.ai) return;
+
+        const weapon = this.equipment.weapon;
+        if (weapon && weapon.tags.includes('ranged')) {
+            this.ai = new RangedAI();
+        } else {
+            this.ai = new MeleeAI();
+        }
+    }
 
     render(ctx) {
         if (this.image) {
@@ -77,13 +97,18 @@ export class Monster extends Entity {
 
 export class Item {
     constructor(x, y, tileSize, name, image) {
-        this.id = Math.random().toString(36).substr(2, 9);
-        this.x = x;
-        this.y = y;
-        this.name = name;
-        this.image = image;
-        this.width = tileSize;
-        this.height = tileSize;
+        this.x = x; this.y = y; this.width = tileSize; this.height = tileSize;
+        this.name = name; this.image = image;
+        this.baseId = '';
+        this.tags = [];
+        const statsMap = new Map();
+        statsMap.add = function(statObj) {
+            for (const key in statObj) {
+                this.set(key, (this.get(key) || 0) + statObj[key]);
+            }
+        };
+        this.stats = statsMap;
+        this.sockets = [];
     }
 
     render(ctx) {

--- a/src/managers.js
+++ b/src/managers.js
@@ -299,6 +299,21 @@ export class ItemManager {
     }
 }
 
+export class EquipmentManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+    }
+
+    equip(entity, item) {
+        if (item.type === 'weapon') {
+            entity.equipment.weapon = item;
+            entity.updateAI();
+            this.eventManager.publish('log', { message: `${entity.constructor.name} (이)가 ${item.name} (을)를 장착했다.` });
+        }
+        // ... (나중에 armor, accessory 처리 로직 추가)
+    }
+}
+
 export class MetaAIManager extends BaseMetaAI {
     executeAction(entity, action, context) {
         if (!action) return;


### PR DESCRIPTION
## Summary
- add new data for items and affixes
- extend factory with ItemFactory
- extend entities to support equipment and dynamic AI
- implement EquipmentManager
- integrate ItemFactory and EquipmentManager in main game loop

## Testing
- `node -c main.js`
- `node -c src/factory.js`
- `node -c src/entities.js`


------
https://chatgpt.com/codex/tasks/task_e_6851996878f88327bd65c322f9600411