### PR TITLE
Add item and equipment system

### DIFF
--- a/src/data/affixes.js
+++ b/src/data/affixes.js
@@ -1,0 +1,9 @@
+export const PREFIXES = {
+    sharp: { name: '날카로운', stats: { attackPower: 2 } },
+    sturdy: { name: '견고한', stats: { maxHp: 5 } },
+};
+
+export const SUFFIXES = {
+    of_strength: { name: '힘의', stats: { strength: 1 } },
+    of_agility: { name: '민첩의', stats: { agility: 1 } },
+};

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -1,0 +1,8 @@
+export const ITEMS = {
+    // 무기
+    short_sword: { name: '단검', type: 'weapon', tags: ['melee', 'sword'], imageKey: 'sword' },
+    long_bow: { name: '장궁', type: 'weapon', tags: ['ranged', 'bow'], imageKey: 'bow' },
+
+    // 방어구
+    leather_armor: { name: '가죽 갑옷', type: 'armor', tags: ['armor', 'light_armor'], imageKey: 'leather_armor' },
+};

--- a/src/entities.js
+++ b/src/entities.js
@@ -1,6 +1,6 @@
 // src/entities.js
 
-import { MeleeAI } from './ai.js';
+import { MeleeAI, RangedAI } from './ai.js';
 import { StatManager } from './stats.js';
 
 class Entity {
@@ -21,6 +21,14 @@ class Entity {
         this.isPlayer = false;
         this.isFriendly = false;
         this.ai = null;
+
+        // --- 장비창(Equipment) 추가 ---
+        this.equipment = {
+            weapon: null,
+            armor: null,
+            accessory1: null,
+            accessory2: null,
+        };
     }
 
     get speed() { return this.stats.get('movementSpeed'); }
@@ -29,6 +37,18 @@ class Entity {
     get expValue() { return this.stats.get('expValue'); }
     get visionRange() { return this.stats.get('visionRange'); }
     get attackRange() { return this.stats.get('attackRange'); }
+
+    // --- AI를 동적으로 변경하는 메서드 추가 ---
+    updateAI() {
+        if (!this.ai) return;
+
+        const weapon = this.equipment.weapon;
+        if (weapon && weapon.tags.includes('ranged')) {
+            this.ai = new RangedAI();
+        } else {
+            this.ai = new MeleeAI();
+        }
+    }
 
     render(ctx) {
         if (this.image) {
@@ -77,13 +97,18 @@ export class Monster extends Entity {
 
 export class Item {
     constructor(x, y, tileSize, name, image) {
-        this.id = Math.random().toString(36).substr(2, 9);
-        this.x = x;
-        this.y = y;
-        this.name = name;
-        this.image = image;
-        this.width = tileSize;
-        this.height = tileSize;
+        this.x = x; this.y = y; this.width = tileSize; this.height = tileSize;
+        this.name = name; this.image = image;
+        this.baseId = '';
+        this.tags = [];
+        const statsMap = new Map();
+        statsMap.add = function(statObj) {
+            for (const key in statObj) {
+                this.set(key, (this.get(key) || 0) + statObj[key]);
+            }
+        };
+        this.stats = statsMap;
+        this.sockets = [];
     }
 
     render(ctx) {

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,9 +1,11 @@
 // src/factory.js
-import { Player, Mercenary, Monster } from './entities.js';
+import { Player, Mercenary, Monster, Item } from './entities.js';
 import { rollOnTable } from './utils/random.js';
 import { FAITHS } from './data/faiths.js';
 import { ORIGINS } from './data/origins.js';
 import { TRAITS } from './data/traits.js';
+import { ITEMS } from './data/items.js';
+import { PREFIXES, SUFFIXES } from './data/affixes.js';
 
 export class CharacterFactory {
     constructor(assets) {
@@ -56,5 +58,49 @@ export class CharacterFactory {
     _rollStars() {
         // ... (별 갯수 랜덤 배분 로직) ...
         return { strength: 1, agility: 1, endurance: 1, focus: 1, intelligence: 1 };
+    }
+}
+
+// === ItemFactory 클래스 새로 추가 ===
+export class ItemFactory {
+    constructor(assets) {
+        this.assets = assets;
+    }
+
+    create(itemId, x, y, tileSize) {
+        const baseItem = ITEMS[itemId];
+        if (!baseItem) return null;
+
+        const item = new Item(x, y, tileSize, baseItem.name, this.assets[baseItem.imageKey]);
+        item.baseId = itemId;
+        item.type = baseItem.type;
+        item.tags = [...baseItem.tags];
+
+        if (Math.random() < 0.5) this._applyAffix(item, PREFIXES, 'prefix');
+        if (Math.random() < 0.5) this._applyAffix(item, SUFFIXES, 'suffix');
+
+        item.sockets = this._createSockets();
+
+        return item;
+    }
+
+    _applyAffix(item, affixPool, type) {
+        const keys = Object.keys(affixPool);
+        const randomKey = keys[Math.floor(Math.random() * keys.length)];
+        const affix = affixPool[randomKey];
+
+        item.name = (type === 'prefix') ? `${affix.name} ${item.name}` : `${item.name} ${affix.name}`;
+        if (!item.stats.add) {
+            item.stats.add = function(statObj) {
+                for (const key in statObj) {
+                    this.set(key, (this.get(key) || 0) + statObj[key]);
+                }
+            };
+        }
+        item.stats.add(affix.stats);
+    }
+
+    _createSockets() {
+        return [];
     }
 }

--- a/src/managers.js
+++ b/src/managers.js
@@ -299,6 +299,21 @@ export class ItemManager {
     }
 }
 
+export class EquipmentManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+    }
+
+    equip(entity, item) {
+        if (item.type === 'weapon') {
+            entity.equipment.weapon = item;
+            entity.updateAI();
+            this.eventManager.publish('log', { message: `${entity.constructor.name} (이)가 ${item.name} (을)를 장착했다.` });
+        }
+        // ... (나중에 armor, accessory 처리 로직 추가)
+    }
+}
+
 export class MetaAIManager extends BaseMetaAI {
     executeAction(entity, action, context) {
         if (!action) return;


### PR DESCRIPTION
## Summary
- add new data for items and affixes
- extend factory with ItemFactory
- extend entities to support equipment and dynamic AI
- implement EquipmentManager
- integrate ItemFactory and EquipmentManager in main game loop
- fix import paths and keep potion logic when equipping items

## Testing
- `node -c main.js`
- `node -c src/factory.js`
- `node -c src/entities.js`
- `node -c src/managers.js`
- `node -c src/data/items.js`
- `node -c src/data/affixes.js`


------
https://chatgpt.com/codex/tasks/task_e_6851996878f88327bd65c322f9600411