### PR TITLE
Fix equipment UI and data path

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,12 +52,16 @@ window.onload = function() {
         const mercenaryManager = new MercenaryManager(assets);
         const itemManager = new ItemManager(20, mapManager, assets);
         const uiManager = new UIManager();
+        const originalUseItem = uiManager.useItem.bind(uiManager);
         uiManager.useItem = function(itemIndex, gameState) {
             const item = gameState.inventory[itemIndex];
+            if (!item) return;
             if (item.type === 'weapon' || item.type === 'armor') {
                 equipmentManager.equip(gameState.player, item);
                 gameState.inventory.splice(itemIndex, 1);
-                return;
+                this.updateUI(gameState);
+            } else {
+                originalUseItem(itemIndex, gameState);
             }
         };
         const metaAIManager = new MetaAIManager(eventManager);

--- a/src/factory.js
+++ b/src/factory.js
@@ -4,8 +4,8 @@ import { rollOnTable } from './utils/random.js';
 import { FAITHS } from './data/faiths.js';
 import { ORIGINS } from './data/origins.js';
 import { TRAITS } from './data/traits.js';
-import { ITEMS } from '../data/items.js';
-import { PREFIXES, SUFFIXES } from '../data/affixes.js';
+import { ITEMS } from './data/items.js';
+import { PREFIXES, SUFFIXES } from './data/affixes.js';
 
 export class CharacterFactory {
     constructor(assets) {


### PR DESCRIPTION
## Summary
- import item data correctly within `ItemFactory`
- keep original item usage logic while adding equipment support

## Testing
- `node -e "console.log('sanity')"`

------
https://chatgpt.com/codex/tasks/task_e_68519c332c708327a2149ffa61145007