### PR TITLE
Improve AI movement handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,8 @@ import { SaveLoadManager } from './src/saveLoadManager.js';
 import { LayerManager } from './src/layerManager.js';
 import { PathfindingManager } from './src/pathfindingManager.js';
 import { FogManager } from './src/fogManager.js';
+import { NarrativeManager } from './src/narrativeManager.js';
+import { TurnManager } from './src/turnManager.js';
 
 window.onload = function() {
     const loader = new AssetLoader();
@@ -52,6 +54,8 @@ window.onload = function() {
         const mercenaryManager = new MercenaryManager(assets);
         const itemManager = new ItemManager(20, mapManager, assets);
         const uiManager = new UIManager();
+        const narrativeManager = new NarrativeManager();
+        const turnManager = new TurnManager();
         const originalUseItem = uiManager.useItem.bind(uiManager);
         uiManager.useItem = function(itemIndex, gameState) {
             const item = gameState.inventory[itemIndex];
@@ -232,8 +236,11 @@ window.onload = function() {
             uiManager.updateUI(gameState);
         }
 
-        function update() {
-            if (gameState.isGameOver) return;
+       function update() {
+           if (gameState.isGameOver) return;
+
+            const allEntities = [gameState.player, ...mercenaryManager.mercenaries, ...monsterManager.monsters];
+            turnManager.update(allEntities); // 턴 매니저 업데이트
             eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update Start ---' });
             const player = gameState.player;
             if (player.attackCooldown > 0) player.attackCooldown--;

--- a/src/ai-managers.js
+++ b/src/ai-managers.js
@@ -77,7 +77,12 @@ export class MetaAIManager {
                 const dx = targetX - entity.x;
                 const dy = targetY - entity.y;
                 const distance = Math.sqrt(dx * dx + dy * dy);
-                if (distance > 1) {
+                if (distance <= entity.speed) {
+                    if (!context.mapManager.isWallAt(targetX, targetY, entity.width, entity.height)) {
+                        entity.x = targetX;
+                        entity.y = targetY;
+                    }
+                } else {
                     let moveX = (dx / distance) * entity.speed;
                     let moveY = (dy / distance) * entity.speed;
                     const newX = entity.x + moveX;

--- a/src/ai.js
+++ b/src/ai.js
@@ -45,7 +45,11 @@ export class MeleeAI extends AIArchetype {
                 // 공격 범위 안에 있으면 공격
                 return { type: 'attack', target: nearestTarget };
             } else {
-                // 공격 범위 밖에 있으면 추격
+            // === 이동 로직 수정 ===
+            // 목표와의 거리가 자신의 속도보다 같거나 작으면, 더 이상 접근하지 않고 대기
+            if (minDistance <= self.speed) {
+                return { type: 'idle' };
+            }
                 return { type: 'move', target: nearestTarget };
             }
         } else if (self.isFriendly && !self.isPlayer) {

--- a/src/managers.js
+++ b/src/managers.js
@@ -333,7 +333,12 @@ export class MetaAIManager extends BaseMetaAI {
                 const dx = action.target.x - entity.x;
                 const dy = action.target.y - entity.y;
                 const distance = Math.sqrt(dx * dx + dy * dy);
-                if (distance > 1) {
+                if (distance <= entity.speed) {
+                    if (!mapManager.isWallAt(action.target.x, action.target.y, entity.width, entity.height)) {
+                        entity.x = action.target.x;
+                        entity.y = action.target.y;
+                    }
+                } else {
                     let moveX = (dx / distance) * entity.speed;
                     let moveY = (dy / distance) * entity.speed;
                     const newX = entity.x + moveX;

--- a/src/narrativeManager.js
+++ b/src/narrativeManager.js
@@ -1,0 +1,14 @@
+// src/narrativeManager.js
+// 게임의 서사, 스토리라인, 도감 등을 관리할 매니저 (구멍만 파기)
+export class NarrativeManager {
+    constructor() {
+        this.storyFlags = {};
+        this.monsterCodex = new Set();
+    }
+    setFlag(key, value) {
+        this.storyFlags[key] = value;
+    }
+    getFlag(key) {
+        return this.storyFlags[key];
+    }
+}

--- a/src/turnManager.js
+++ b/src/turnManager.js
@@ -1,0 +1,24 @@
+// src/turnManager.js
+// 턴 기반의 상태 변화를 관리할 매니저 (구멍만 파기)
+export class TurnManager {
+    constructor() {
+        this.turnCount = 0;
+        this.framesPerTurn = 100; // 100프레임을 1턴으로 간주
+        this.currentFrame = 0;
+    }
+
+    update(entities) {
+        this.currentFrame++;
+        if (this.currentFrame >= this.framesPerTurn) {
+            this.currentFrame = 0;
+            this.turnCount++;
+            
+            // 여기에 턴마다 발생하는 로직 추가
+            // 예: 모든 유닛의 배부름 0.1 감소, 호감도 0.1 증가 등
+            // entities.forEach(e => {
+            //     e.hunger -= 0.1;
+            //     e.affinity += 0.1;
+            // });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refine MeleeAI close-range idle behavior
- prevent overshoot by snapping to the target when within movement speed
- update MetaAIManager movement accordingly

## Testing
- `node --check main.js`
- `node --check src/ai.js`
- `node --check src/ai-managers.js`
- `node --check src/managers.js`
- `node --check src/narrativeManager.js`
- `node --check src/turnManager.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5f70dbc8327848a34a994af8c27