### PR TITLE
Add mercenary exp view and update exp sharing

### DIFF
--- a/main.js
+++ b/main.js
@@ -159,7 +159,15 @@ window.onload = function() {
             eventManager.publish('log', { message: `${victim.constructor.name}가 쓰러졌습니다.`, color: 'red' });
 
             if (!victim.isFriendly && (attacker.isPlayer || attacker.isFriendly)) {
-                eventManager.publish('exp_gained', { player: attacker, exp: victim.expValue });
+                if (attacker.isPlayer) {
+                    // 플레이어가 직접 처치한 경우 전체 경험치 지급
+                    eventManager.publish('exp_gained', { player: attacker, exp: victim.expValue });
+                } else if (attacker.isFriendly) {
+                    // 용병이 처치한 경우 용병과 플레이어가 경험치를 절반씩 나눔
+                    const sharedExp = victim.expValue / 2;
+                    eventManager.publish('exp_gained', { player: attacker, exp: sharedExp });
+                    eventManager.publish('exp_gained', { player: gameState.player, exp: sharedExp });
+                }
             }
         });
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -25,7 +25,8 @@ export class CharacterFactory {
         // 2. 기본 스탯 설정 (직업, 몬스터 종류, 출신 보너스 등)
         const baseStats = { ...(config.baseStats || {}) };
         if (type === 'monster' && baseStats.expValue === undefined) {
-            baseStats.expValue = 5;
+            // 기본 몬스터 경험치를 10으로 상향
+            baseStats.expValue = 10;
         }
         const originBonus = ORIGINS[originId].stat_bonuses;
         for (const stat in originBonus) {

--- a/src/managers.js
+++ b/src/managers.js
@@ -162,6 +162,18 @@ export class UIManager {
 
         const statsToShow = ['hp', 'maxHp', 'attackPower', 'strength', 'agility', 'endurance', 'movementSpeed'];
         this.mercStatsContainer.innerHTML = '';
+
+        // 레벨 및 경험치 표시
+        const levelDiv = document.createElement('div');
+        levelDiv.className = 'stat-line';
+        levelDiv.textContent = `레벨: ${mercenary.stats.get('level')}`;
+        this.mercStatsContainer.appendChild(levelDiv);
+
+        const expDiv = document.createElement('div');
+        expDiv.className = 'stat-line';
+        expDiv.textContent = `EXP: ${mercenary.stats.get('exp')} / ${mercenary.stats.get('expNeeded')}`;
+        this.mercStatsContainer.appendChild(expDiv);
+
         statsToShow.forEach(stat => {
             const statDiv = document.createElement('div');
             statDiv.className = 'stat-line';


### PR DESCRIPTION
## Summary
- make normal monsters worth 10 EXP by default
- split EXP between player and mercenaries when mercenaries get kills
- display mercenary level and EXP in the detail panel

## Testing
- `node -c main.js`
- `node -c src/factory.js`
- `node -c src/managers.js`


------
https://chatgpt.com/codex/tasks/task_e_685217444cc08327acf08f560d2fea7a