### PR TITLE
Improve AI pathfinding around walls

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -31,27 +31,26 @@ export class MeleeAI extends AIArchetype {
         }
 
         // 2. 행동 결정
-        if (nearestTarget &&
-            minDistance < self.visionRange &&
-            hasLineOfSight(
+        if (nearestTarget && minDistance < self.visionRange) {
+            const hasLOS = hasLineOfSight(
                 Math.floor(self.x / mapManager.tileSize),
                 Math.floor(self.y / mapManager.tileSize),
                 Math.floor(nearestTarget.x / mapManager.tileSize),
                 Math.floor(nearestTarget.y / mapManager.tileSize),
                 mapManager
-            )) {
-            // 적이 시야 안에 있을 경우
-            if (minDistance < self.attackRange) {
+            );
+            if (hasLOS && minDistance < self.attackRange) {
                 // 공격 범위 안에 있으면 공격
                 return { type: 'attack', target: nearestTarget };
-            } else {
-            // === 이동 로직 수정 ===
-            // 목표와의 거리가 자신의 속도보다 같거나 작으면, 더 이상 접근하지 않고 대기
-            if (minDistance <= self.speed) {
+            }
+
+            if (hasLOS && minDistance <= self.speed) {
+                // 너무 가까우면 더 이상 다가가지 않음
                 return { type: 'idle' };
             }
-                return { type: 'move', target: nearestTarget };
-            }
+
+            // 목표 지점을 향해 이동 (시야가 가려져 있어도 탐색)
+            return { type: 'move', target: nearestTarget };
         } else if (self.isFriendly && !self.isPlayer) {
             // 아군이고, 적이 없으면 플레이어를 따라다님
             const playerDistance = Math.sqrt(Math.pow(player.x - self.x, 2) + Math.pow(player.y - self.y, 2));

--- a/src/pathfindingManager.js
+++ b/src/pathfindingManager.js
@@ -5,10 +5,7 @@ export class PathfindingManager {
         this.mapManager = mapManager;
     }
 
-    // 간단한 BFS 기반 길찾기 구현
-    findPath(startX, startY, endX, endY) {
-        console.log(`Pathfinding from (${startX},${startY}) to (${endX},${endY})`);
-
+    _bfs(startX, startY, endX, endY) {
         const { map, width, height, tileTypes } = this.mapManager;
 
         if (startX === endX && startY === endY) return [];
@@ -54,5 +51,32 @@ export class PathfindingManager {
         }
 
         return []; // 경로를 찾지 못한 경우 빈 배열 반환
+    }
+
+    // 타겟 주변의 이동 가능한 위치까지 경로를 찾는다.
+    findPath(startX, startY, endX, endY) {
+        console.log(`Pathfinding from (${startX},${startY}) to (${endX},${endY})`);
+
+        const basePath = this._bfs(startX, startY, endX, endY);
+        if (basePath.length > 0) return basePath;
+
+        const { map, width, height, tileTypes } = this.mapManager;
+        const dirs = [
+            { x: 1, y: 0 }, { x: -1, y: 0 },
+            { x: 0, y: 1 }, { x: 0, y: -1 }
+        ];
+        let bestPath = [];
+        for (const dir of dirs) {
+            const nx = endX + dir.x;
+            const ny = endY + dir.y;
+            if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+            if (map[ny][nx] === tileTypes.WALL) continue;
+            const path = this._bfs(startX, startY, nx, ny);
+            if (path.length > 0 && (bestPath.length === 0 || path.length < bestPath.length)) {
+                bestPath = path;
+            }
+        }
+
+        return bestPath;
     }
 }


### PR DESCRIPTION
## Summary
- enhance `PathfindingManager` with fallback search around target
- allow melee AI to move toward targets even without direct line of sight

## Testing
- `node -e "import './src/ai.js'; import './src/pathfindingManager.js'; console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_68521a2aba608327a36607d1b364b5c9