### PR TITLE
Add mercenary equipment system

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,13 @@
         </div>
     </div>
 
+    <div id="equipment-target-panel" class="modal-panel hidden">
+        <button id="close-equip-target-btn" class="close-btn">X</button>
+        <h2>누구에게 장착하시겠습니까?</h2>
+        <div id="equipment-target-list">
+        </div>
+    </div>
+
 
 
     <script type="module" src="main.js"></script>

--- a/src/entities.js
+++ b/src/entities.js
@@ -13,7 +13,8 @@ class Entity {
         this.image = image;
         this.tileSize = tileSize;
         this.properties = properties || {};
-        this.stats = new StatManager(stats || {}, this);
+        // StatManager가 entity 자신을 참조하도록 첫 번째 인자로 전달
+        this.stats = new StatManager(this, stats || {});
         this.width = this.stats.get('sizeInTiles_w') * tileSize;
         this.height = this.stats.get('sizeInTiles_h') * tileSize;
         this.hp = this.stats.get('maxHp');

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,7 +1,8 @@
 // src/stats.js
 
 export class StatManager {
-    constructor(config = {}, entity) {
+    constructor(entity, config = {}) {
+        // entity 자신을 참조할 수 있도록 저장
         this.entity = entity;
         this._baseStats = {
             level: config.level || 1,
@@ -22,6 +23,10 @@ export class StatManager {
         this._pointsAllocated = {
             strength: 0, agility: 0, endurance: 0, focus: 0, intelligence: 0, movement: 0,
         };
+
+        // 장비로부터 적용되는 스탯 저장용
+        this._fromEquipment = {};
+
         this.derivedStats = {};
         this.recalculate();
     }
@@ -32,10 +37,28 @@ export class StatManager {
         }
     }
 
+    // 장비 스탯을 업데이트하는 함수
+    updateEquipmentStats() {
+        this._fromEquipment = {};
+        if (!this.entity || !this.entity.equipment) return;
+
+        for (const slot in this.entity.equipment) {
+            const item = this.entity.equipment[slot];
+            if (item && item.stats) {
+                for (const [stat, value] of item.stats.entries()) {
+                    this._fromEquipment[stat] = (this._fromEquipment[stat] || 0) + value;
+                }
+            }
+        }
+        this.recalculate();
+    }
+
     recalculate() {
         const final = {};
         for (const stat in this._baseStats) {
-            final[stat] = (this._baseStats[stat] || 0) + (this._pointsAllocated[stat] || 0);
+            final[stat] = (this._baseStats[stat] || 0)
+                       + (this._pointsAllocated[stat] || 0)
+                       + (this._fromEquipment[stat] || 0);
         }
 
         final.maxHp = 10 + final.endurance * 5;


### PR DESCRIPTION
## Summary
- compute equipment bonuses in StatManager
- pass entity to StatManager constructor and update Entity accordingly
- implement EquipmentManager.equip with slot logic
- let UI show equipment target selection and handle equipping
- expose equip target UI in HTML
- wire equipment logic into main initialization
- fix slot detection to use item.type and number mercenary buttons

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `node -c src/managers.js`


------
https://chatgpt.com/codex/tasks/task_e_68521c7b5e40832792abd6c2bd2ec1eb