### PR TITLE
Fix item equip click bug

### DIFF
--- a/src/managers.js
+++ b/src/managers.js
@@ -251,7 +251,8 @@ export class UIManager {
         const item = gameState.inventory[itemIndex];
         if (!item) return;
 
-        if (item.tags.includes('weapon') || item.tags.includes('armor')) {
+        if (item.tags.includes('weapon') || item.tags.includes('armor') ||
+            item.type === 'weapon' || item.type === 'armor') {
             this._showEquipTargetPanel(item, gameState);
         } else if (item.name === 'potion') {
             const player = gameState.player;


### PR DESCRIPTION
## Summary
- allow equipping items by checking `item.type` as well as tags

## Testing
- `node --check src/managers.js`

------
https://chatgpt.com/codex/tasks/task_e_68521fe8443c832790656a290e57257a