### PR TITLE
Fix weapon attack bonus

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -1,8 +1,26 @@
 export const ITEMS = {
     // 무기
-    short_sword: { name: '단검', type: 'weapon', tags: ['melee', 'sword'], imageKey: 'sword' },
-    long_bow: { name: '장궁', type: 'weapon', tags: ['ranged', 'bow'], imageKey: 'bow' },
+    short_sword: {
+        name: '단검',
+        type: 'weapon',
+        tags: ['melee', 'sword'],
+        imageKey: 'sword',
+        stats: { attackPower: 2 },
+    },
+    long_bow: {
+        name: '장궁',
+        type: 'weapon',
+        tags: ['ranged', 'bow'],
+        imageKey: 'bow',
+        stats: { attackPower: 2 },
+    },
 
     // 방어구
-    leather_armor: { name: '가죽 갑옷', type: 'armor', tags: ['armor', 'light_armor'], imageKey: 'leather_armor' },
+    leather_armor: {
+        name: '가죽 갑옷',
+        type: 'armor',
+        tags: ['armor', 'light_armor'],
+        imageKey: 'leather_armor',
+        stats: { maxHp: 5 },
+    },
 };

--- a/src/factory.js
+++ b/src/factory.js
@@ -76,6 +76,9 @@ export class ItemFactory {
         item.baseId = itemId;
         item.type = baseItem.type;
         item.tags = [...baseItem.tags];
+        if (baseItem.stats) {
+            item.stats.add(baseItem.stats);
+        }
 
         if (Math.random() < 0.5) this._applyAffix(item, PREFIXES, 'prefix');
         if (Math.random() < 0.5) this._applyAffix(item, SUFFIXES, 'suffix');


### PR DESCRIPTION
## Summary
- add base stat bonuses to items
- apply base stats when creating items

## Testing
- `node -e "require('./src/data/items.js'); console.log('items loaded');"`
- `node - <<'NODE'
const { ItemFactory } = require('./src/factory.js');
const factory = new ItemFactory({sword:null});
const item = factory.create('short_sword',0,0,32);
console.log(item.name, Array.from(item.stats.entries()));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_685238b387408327866bdac0caa21b4f