### PR TITLE
Fix top menu bar hidden behind canvas

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,6 +16,31 @@ body, html {
     z-index: 1; /* 가장 아래에 있는 레이어 */
 }
 
+/* 상단 메뉴 바가 캔버스 레이어 위에 보이도록 설정 */
+#top-menu-bar {
+    position: fixed;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 120;
+    background: rgba(0, 0, 0, 0.5);
+    padding: 5px 10px;
+    border-radius: 5px;
+}
+
+.menu-btn {
+    margin-right: 5px;
+    color: #fff;
+    background: #333;
+    border: 1px solid #777;
+    padding: 4px 8px;
+    cursor: pointer;
+}
+
+.menu-btn:last-child {
+    margin-right: 0;
+}
+
 .game-layer {
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Summary
- keep top menu bar visible above game canvas layers
- add simple styles for menu buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685243691d208327a5387c78821bd247