### PR TITLE
Fix mercenary equipment attack bonus

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -62,7 +62,7 @@ export class StatManager {
         }
 
         final.maxHp = 10 + final.endurance * 5;
-        final.attackPower = 1 + final.strength * 2;
+        final.attackPower = (final.attackPower || 0) + 1 + final.strength * 2;
         final.movementSpeed = final.movement;
 
         this.derivedStats = final;


### PR DESCRIPTION
## Summary
- include attackPower bonuses from equipment in stat calculation

## Testing
- `node -e "const Map=global.Map; class Item{constructor(){const m=new Map(); m.add=function(o){for(const k in o){this.set(k,(this.get(k)||0)+o[k]);}}; this.stats=m; this.tags=['weapon'];} }; class Entity{constructor(){this.equipment={weapon:null}; this.stats=new (require('./src/stats.js').StatManager)(this,{strength:2});}} const e=new Entity(); const sword=new Item(); sword.stats.add({attackPower:2}); e.equipment.weapon=sword; e.stats.updateEquipmentStats(); console.log('attack', e.stats.get('attackPower'));"`

------
https://chatgpt.com/codex/tasks/task_e_6852479b62dc8327b5cddc7a92e601e8