### PR TITLE
Add weapon overlay rendering for mercenaries

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -89,6 +89,21 @@ export class Mercenary extends Entity {
         this.unitType = 'human'; // 용병의 타입도 '인간'
         this.ai = new MeleeAI();
     }
+
+    render(ctx) {
+        // 1. 기본 이미지를 먼저 그린다
+        super.render(ctx);
+
+        // 2. 장착한 무기가 있으면 그 위에 겹쳐서 그린다
+        const weapon = this.equipment.weapon;
+        if (weapon && weapon.image) {
+            const drawX = this.x + this.width * 0.3;
+            const drawY = this.y + this.height * 0.3;
+            const drawW = this.width * 0.8;
+            const drawH = this.height * 0.8;
+            ctx.drawImage(weapon.image, drawX, drawY, drawW, drawH);
+        }
+    }
 }
 
 export class Monster extends Entity {

--- a/src/factory.js
+++ b/src/factory.js
@@ -72,7 +72,12 @@ export class ItemFactory {
         const baseItem = ITEMS[itemId];
         if (!baseItem) return null;
 
-        const item = new Item(x, y, tileSize, baseItem.name, this.assets[baseItem.imageKey]);
+        // 아이템 생성 시 imageKey로부터 올바른 이미지를 불러온다
+        const itemImage = this.assets[baseItem.imageKey];
+        if (!itemImage) {
+            console.warn(`Missing image for item ${itemId} with key ${baseItem.imageKey}`);
+        }
+        const item = new Item(x, y, tileSize, baseItem.name, itemImage);
         item.baseId = itemId;
         item.type = baseItem.type;
         item.tags = [...baseItem.tags];


### PR DESCRIPTION
## Summary
- display mercenary weapon image on top of default sprite
- clarify image retrieval when creating items
- log missing item images

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685249d311b883278ad9e303b5520490