### PR TITLE
Fix equipment stats not applied

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -45,8 +45,14 @@ export class StatManager {
         for (const slot in this.entity.equipment) {
             const item = this.entity.equipment[slot];
             if (item && item.stats) {
-                for (const [stat, value] of item.stats.entries()) {
-                    this._fromEquipment[stat] = (this._fromEquipment[stat] || 0) + value;
+                if (item.stats instanceof Map) {
+                    for (const [stat, value] of item.stats.entries()) {
+                        this._fromEquipment[stat] = (this._fromEquipment[stat] || 0) + value;
+                    }
+                } else {
+                    for (const [stat, value] of Object.entries(item.stats)) {
+                        this._fromEquipment[stat] = (this._fromEquipment[stat] || 0) + value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- support items that store stats as plain objects in `updateEquipmentStats`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685276dd46208327b74000078435a5b3