### PR TITLE
Add effect manager skeleton and integrate

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,6 +24,7 @@ import { FogManager } from './src/fogManager.js';
 import { NarrativeManager } from './src/narrativeManager.js';
 import { TurnManager } from './src/turnManager.js';
 import { SKILLS } from './src/data/skills.js';
+import { EffectManager } from './src/managers/effectManager.js';
 
 window.onload = function() {
     const loader = new AssetLoader();
@@ -52,6 +53,7 @@ window.onload = function() {
         const saveLoadManager = new SaveLoadManager();
         const turnManager = new TurnManager();
         const narrativeManager = new NarrativeManager();
+        const effectManager = new EffectManager(eventManager);
         const factory = new CharacterFactory(assets);
 
         // --- 새로 추가된 매니저들 생성 ---
@@ -216,6 +218,11 @@ window.onload = function() {
             }
         });
 
+        // 스탯 변경 이벤트 구독 (효과 적용/해제 시 스탯 재계산)
+        eventManager.subscribe('stats_changed', (data) => {
+            data.entity.stats.recalculate();
+        });
+
         // === 3. 게임 로직 ===
         // 공격 처리를 위한 함수는 이벤트만 발행하도록 변경
         function handleAttack(attacker, defender) {
@@ -310,6 +317,7 @@ window.onload = function() {
            if (gameState.isPaused || gameState.isGameOver) return;
 
             const allEntities = [gameState.player, ...mercenaryManager.mercenaries, ...monsterManager.monsters];
+            effectManager.update(allEntities); // EffectManager 업데이트 호출
             turnManager.update(allEntities); // 턴 매니저 업데이트
             eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update Start ---' });
             const player = gameState.player;

--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -1,0 +1,26 @@
+export const EFFECTS = {
+    // 버프
+    strength_buff: {
+        name: '힘의 축복',
+        type: 'buff',
+        duration: 300, // 300프레임 (약 5초)
+        stats: { strength: 5 },
+        tags: ['buff', 'stat_up'],
+    },
+    // 디버프
+    armor_break: {
+        name: '방어구 부수기',
+        type: 'debuff',
+        duration: 300,
+        stats: { defense: -10 },
+        tags: ['debuff', 'stat_down'],
+    },
+    // 상태이상
+    poison: {
+        name: '중독',
+        type: 'dot', // Damage over Time
+        duration: 500, // 5턴 (100프레임당 1턴 기준)
+        damagePerTurn: 2,
+        tags: ['status_ailment', 'poison'],
+    }
+};

--- a/src/entities.js
+++ b/src/entities.js
@@ -25,6 +25,7 @@ class Entity {
         this.isPlayer = false;
         this.isFriendly = false;
         this.ai = null;
+        this.effects = []; // 적용중인 효과 목록 배열 추가
         this.unitType = 'generic'; // 기본 유닛 타입을 '일반'으로 설정
 
         // --- 장비창(Equipment) 추가 ---

--- a/src/managers/effectManager.js
+++ b/src/managers/effectManager.js
@@ -1,0 +1,51 @@
+import { EFFECTS } from '../data/effects.js';
+
+export class EffectManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        console.log("[EffectManager] Initialized");
+    }
+
+    // 특정 유닛에게 효과를 추가하는 함수
+    addEffect(target, effectId) {
+        const effectData = EFFECTS[effectId];
+        if (!effectData) return;
+
+        // 이미 같은 효과가 걸려있다면, 지속시간만 갱신 (나중에 중첩 로직 추가 가능)
+        const existingEffect = target.effects.find(e => e.id === effectId);
+        if (existingEffect) {
+            existingEffect.duration = effectData.duration;
+        } else {
+            const newEffect = { ...effectData, remaining: effectData.duration };
+            target.effects.push(newEffect);
+        }
+
+        // 효과가 적용되면 스탯을 다시 계산하도록 이벤트 발행
+        this.eventManager.publish('stats_changed', { entity: target });
+    }
+
+    // 매 프레임 모든 유닛의 효과를 업데이트
+    update(entities) {
+        entities.forEach(entity => {
+            if (entity.effects.length === 0) return;
+
+            // 효과 지속시간 감소
+            entity.effects.forEach(effect => {
+                effect.remaining--;
+                // (미래 구멍) '독' 같은 상태이상 데미지 처리
+                if (effect.type === 'dot' && effect.remaining % 100 === 0) {
+                    // entity.takeDamage(effect.damagePerTurn);
+                }
+            });
+
+            // 지속시간이 다 된 효과 제거
+            const initialCount = entity.effects.length;
+            entity.effects = entity.effects.filter(effect => effect.remaining > 0);
+
+            // 효과가 제거되었다면, 스탯 재계산 이벤트 발행
+            if (entity.effects.length < initialCount) {
+                this.eventManager.publish('stats_changed', { entity: entity });
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- define basic buff/debuff data in `src/data/effects.js`
- add `EffectManager` for handling timed effects
- store active effects on every entity
- instantiate and update `EffectManager` in the game loop
- recalc stats when effects change

## Testing
- `node tests/statManager.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685285784fac8327bdda50227bed6be4