### PR TITLE
Improve and expand test suite

### DIFF
--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -1,16 +1,38 @@
 import { MeleeAI } from '../src/ai.js';
+import { test, assert } from './helpers.js';
 
 console.log("--- Running AI Tests ---");
-try {
-    const ai = new MeleeAI();
-    const self = { x: 0, y: 0, visionRange: 100, attackRange: 10 };
-    const context = { enemies: [{ x: 5, y: 0 }] }; // 5칸 떨어진 적
 
+const mapStub = { tileSize: 1, isWallAt: () => false };
+
+// 공격 범위 내 적을 공격하는지 확인
+
+test('MeleeAI - 공격 결정', () => {
+    const ai = new MeleeAI();
+    const self = { x: 0, y: 0, visionRange: 100, attackRange: 10, speed: 5, tileSize: 1 };
+    const context = { player: {}, allies: [], enemies: [{ x: 5, y: 0 }], mapManager: mapStub };
     const action = ai.decideAction(self, context);
-    if (action.type !== 'attack') {
-        throw new Error(`공격 범위 내의 적에게 'attack'이 아닌 '${action.type}' 결정`);
-    }
-    console.log("✅ PASSED: MeleeAI - 공격 결정");
-} catch (e) {
-    console.error(`❌ FAILED: MeleeAI - 공격 결정 - ${e.message}`);
-}
+    assert.strictEqual(action.type, 'attack');
+});
+
+// 사정거리 밖의 적에게 이동 명령을 내리는지 확인
+
+test('MeleeAI - 이동 결정', () => {
+    const ai = new MeleeAI();
+    const self = { x: 0, y: 0, visionRange: 100, attackRange: 10, speed: 5, tileSize: 1 };
+    const context = { player: {}, allies: [], enemies: [{ x: 20, y: 0 }], mapManager: mapStub };
+    const action = ai.decideAction(self, context);
+    assert.strictEqual(action.type, 'move');
+});
+
+// 아군이 플레이어를 따라가는지 확인
+
+test('MeleeAI - 플레이어 추적', () => {
+    const ai = new MeleeAI();
+    const self = { x: 0, y: 0, visionRange: 100, attackRange: 10, speed: 5, tileSize: 1, isFriendly: true, isPlayer: false };
+    const player = { x: 10, y: 0 };
+    const context = { player, allies: [], enemies: [], mapManager: mapStub };
+    const action = ai.decideAction(self, context);
+    assert.strictEqual(action.type, 'move');
+    assert.strictEqual(action.target, player);
+});

--- a/tests/combatCalculator.test.js
+++ b/tests/combatCalculator.test.js
@@ -1,17 +1,21 @@
 import { CombatCalculator } from '../src/combat.js';
+import { EventManager } from '../src/eventManager.js';
+import { test, assert } from './helpers.js';
 
 console.log("--- Running CombatCalculator Tests ---");
-try {
-    const calculator = new CombatCalculator(null); // 지금은 eventManager가 필요없음
+
+test('피해량 계산 이벤트', () => {
+    const eventManager = new EventManager();
+    const calculator = new CombatCalculator(eventManager);
+    let eventData = null;
+    eventManager.subscribe('damage_calculated', data => { eventData = data; });
+
     const attacker = { attackPower: 10 };
-    const defender = { defense: 3 }; // 나중에 방어력 스탯 추가 대비
+    const defender = {};
+    calculator.handleAttack({ attacker, defender });
 
-    const damage = calculator.calculateDamage(attacker, defender);
-
-    if (damage !== 10) {
-        throw new Error(`예상 피해량 10, 실제 피해량 ${damage}`);
-    }
-    console.log("✅ PASSED: 피해량 계산");
-} catch (e) {
-    console.error(`❌ FAILED: 피해량 계산 - ${e.message}`);
-}
+    assert.ok(eventData, '이벤트 수신 여부');
+    assert.strictEqual(eventData.damage, 10);
+    assert.strictEqual(eventData.attacker, attacker);
+    assert.strictEqual(eventData.defender, defender);
+});

--- a/tests/effectManager.test.js
+++ b/tests/effectManager.test.js
@@ -1,18 +1,19 @@
 import { EffectManager } from '../src/managers/effectManager.js';
 import { EventManager } from '../src/eventManager.js';
+import { test, assert } from './helpers.js';
 
 console.log("--- Running EffectManager Tests ---");
-try {
+
+test('버프 추가', () => {
     const eventManager = new EventManager();
     const effectManager = new EffectManager(eventManager);
     const mockTarget = { effects: [], stats: { recalculate: () => {} } };
+    let eventFired = false;
+    eventManager.subscribe('stats_changed', () => { eventFired = true; });
 
     effectManager.addEffect(mockTarget, 'strength_buff');
 
-    if (mockTarget.effects.length !== 1 || mockTarget.effects[0].id !== 'strength_buff') {
-        throw new Error("버프가 정상적으로 추가되지 않음");
-    }
-    console.log("✅ PASSED: 버프 추가");
-} catch (e) {
-    console.error(`❌ FAILED: 버프 추가 - ${e.message}`);
-}
+    assert.strictEqual(mockTarget.effects.length, 1);
+    assert.strictEqual(mockTarget.effects[0].name, '힘의 축복');
+    assert.ok(eventFired, 'stats_changed 이벤트');
+});

--- a/tests/eventManager.test.js
+++ b/tests/eventManager.test.js
@@ -1,0 +1,12 @@
+import { EventManager } from '../src/eventManager.js';
+import { test, assert } from './helpers.js';
+
+console.log("--- Running EventManager Tests ---");
+
+test('publish가 구독자 호출', () => {
+    const em = new EventManager();
+    let called = false;
+    em.subscribe('test', () => { called = true; });
+    em.publish('test', {});
+    assert.ok(called);
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,12 @@
+import assert from 'assert';
+
+export function test(name, fn) {
+    try {
+        fn();
+        console.log(`✅ PASSED: ${name}`);
+    } catch (e) {
+        console.error(`❌ FAILED: ${name} - ${e.message}`);
+    }
+}
+
+export { assert };

--- a/tests/pathfindingManager.test.js
+++ b/tests/pathfindingManager.test.js
@@ -1,13 +1,30 @@
 import { PathfindingManager } from '../src/pathfindingManager.js';
+import { test, assert } from './helpers.js';
 
 console.log("--- Running PathfindingManager Tests ---");
-try {
-    // PathfindingManager는 mapManager에 의존하므로, 지금은 생성만 테스트
+
+test('생성', () => {
     const pfManager = new PathfindingManager(null);
-    if (!pfManager) {
-        throw new Error("PathfindingManager 생성 실패");
-    }
-    console.log("✅ PASSED: 생성 (구현 필요)");
-} catch (e) {
-    console.error(`❌ FAILED: 생성 - ${e.message}`);
-}
+    assert.ok(pfManager);
+});
+
+test('단순 경로 탐색', () => {
+    const mapManager = {
+        map: [
+            [0,0,0],
+            [0,0,0],
+            [0,0,0]
+        ],
+        width: 3,
+        height:3,
+        tileSize:1,
+        tileTypes: { FLOOR:0, WALL:1 },
+        isWallAt(x,y){
+            const tx = Math.floor(x/1); const ty=Math.floor(y/1);
+            return this.map[ty][tx]===this.tileTypes.WALL;
+        }
+    };
+    const pfManager = new PathfindingManager(mapManager);
+    const path = pfManager.findPath(0,0,2,0);
+    assert.deepStrictEqual(path, [{x:1,y:0},{x:2,y:0}]);
+});

--- a/tests/random.test.js
+++ b/tests/random.test.js
@@ -1,16 +1,13 @@
 import { rollOnTable } from '../src/utils/random.js';
+import { test, assert } from './helpers.js';
 
 console.log("--- Running Random (DiceBot) Tests ---");
-try {
+
+test('가중치 기반 롤링', () => {
     const testTable = [
         { id: 'success', weight: 100 },
         { id: 'fail', weight: 0 },
     ];
     const result = rollOnTable(testTable);
-    if (result !== 'success') {
-        throw new Error(`100% 확률 테스트에서 'success'가 아닌 '${result}'가 나옴`);
-    }
-    console.log("✅ PASSED: 가중치 기반 롤링");
-} catch (e) {
-    console.error(`❌ FAILED: 가중치 기반 롤링 - ${e.message}`);
-}
+    assert.strictEqual(result, 'success');
+});

--- a/tests/statManager.test.js
+++ b/tests/statManager.test.js
@@ -1,56 +1,43 @@
-// tests/statManager.test.js
-
-// 테스트할 대상인 StatManager를 불러옵니다.
 import { StatManager } from '../src/stats.js';
+import { test, assert } from './helpers.js';
 
-// 테스트를 위한 간단한 'assertion' 함수 (A와 B가 같은지 확인)
-function assertEquals(a, b, message) {
-    if (a !== b) {
-        throw new Error(`Assertion failed: ${message}. Expected ${b}, but got ${a}.`);
-    }
-}
-
-// --- StatManager 테스트 스위트 ---
 console.log("--- Running StatManager Tests ---");
 
-// 테스트 1: 초기 스탯이 올바르게 설정되는가?
-try {
+// 초기 스탯이 올바르게 설정되는가?
+test('초기 스탯 설정', () => {
     const jobConfig = { strength: 5, endurance: 10 };
     const stats = new StatManager({}, jobConfig);
-    assertEquals(stats.get('strength'), 5, "초기 힘 스탯");
-    assertEquals(stats.get('endurance'), 10, "초기 체력 스탯");
-    console.log("✅ PASSED: 초기 스탯 설정");
-} catch (e) {
-    console.error(`❌ FAILED: 초기 스탯 설정 - ${e.message}`);
-}
+    assert.strictEqual(stats.get('strength'), 5);
+    assert.strictEqual(stats.get('endurance'), 10);
+});
 
-// 테스트 2: 파생 스탯(maxHp, attackPower)이 올바르게 계산되는가?
-try {
+// 파생 스탯(maxHp, attackPower)이 올바르게 계산되는가?
+test('파생 스탯 계산', () => {
     const jobConfig = { strength: 5, endurance: 10 };
     const stats = new StatManager({}, jobConfig);
-    // maxHp = 10 + endurance * 5  => 10 + 10 * 5 = 60
-    assertEquals(stats.get('maxHp'), 60, "최대 HP 계산");
-    // attackPower = 1 + strength * 2 => 1 + 5 * 2 = 11
-    assertEquals(stats.get('attackPower'), 11, "공격력 계산");
-    console.log("✅ PASSED: 파생 스탯 계산");
-} catch (e) {
-    console.error(`❌ FAILED: 파생 스탯 계산 - ${e.message}`);
-}
+    assert.strictEqual(stats.get('maxHp'), 60); // 10 + 10 * 5
+    assert.strictEqual(stats.get('attackPower'), 11); // 1 + 5 * 2
+});
 
-// 테스트 3: 스탯 포인트 분배가 올바르게 작동하는가?
-try {
+// 스탯 포인트 분배가 올바르게 작동하는가?
+test('스탯 포인트 분배', () => {
     const jobConfig = { strength: 5, endurance: 10 };
     const stats = new StatManager({}, jobConfig);
-    
-    stats.allocatePoint('strength'); // 힘 1포인트 투자
+    stats.allocatePoint('strength');
     stats.recalculate();
+    assert.strictEqual(stats.get('strength'), 6);
+    assert.strictEqual(stats.get('attackPower'), 13);
+});
 
-    assertEquals(stats.get('strength'), 6, "힘 포인트 투자 후 스탯");
-    assertEquals(stats.get('attackPower'), 13, "힘 포인트 투자 후 공격력 재계산");
-    console.log("✅ PASSED: 스탯 포인트 분배");
-} catch (e) {
-    console.error(`❌ FAILED: 스탯 포인트 분배 - ${e.message}`);
-}
+// 레벨 업 시 스탯 증가 확인
+
+test('레벨 업', () => {
+    const stats = new StatManager({}, { strength: 1, endurance: 1, expNeeded: 10 });
+    stats.levelUp();
+    stats.recalculate();
+    assert.strictEqual(stats.get('level'), 2);
+    assert.strictEqual(stats.get('strength'), 2);
+    assert.strictEqual(stats.get('endurance'), 2);
+});
 
 console.log("--- StatManager Tests Finished ---");
-

--- a/tests/turnManager.test.js
+++ b/tests/turnManager.test.js
@@ -1,16 +1,13 @@
 import { TurnManager } from '../src/turnManager.js';
+import { test, assert } from './helpers.js';
 
 console.log("--- Running TurnManager Tests ---");
-try {
+
+test('턴 카운트 증가', () => {
     const turnManager = new TurnManager();
     turnManager.framesPerTurn = 10;
     for (let i = 0; i < 10; i++) {
         turnManager.update([]);
     }
-    if (turnManager.turnCount !== 1) {
-        throw new Error(`10프레임 후 턴 카운트가 1이 아님 (실제: ${turnManager.turnCount})`);
-    }
-    console.log("✅ PASSED: 턴 카운트 증가");
-} catch (e) {
-    console.error(`❌ FAILED: 턴 카운트 증가 - ${e.message}`);
-}
+    assert.strictEqual(turnManager.turnCount, 1);
+});


### PR DESCRIPTION
## Summary
- centralize tiny test helper
- update all existing tests to use helper and `assert`
- add event manager tests
- add extra coverage for AI, pathfinding and stats

## Testing
- `node tests/eventManager.test.js`
- `node tests/ai.test.js`
- `node tests/pathfindingManager.test.js`
- `node tests/turnManager.test.js`
- `node tests/random.test.js`
- `node tests/effectManager.test.js`
- `node tests/statManager.test.js`
- `node tests/combatCalculator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6852873e6c4c8327bc2b3422e4f69eeb