### PR TITLE
Add map debugger and connectivity test

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Map Debugger</title>
+    <style>
+        body { background-color: #333; color: white; display: flex; flex-direction: column; align-items: center; }
+        canvas { border: 1px solid white; image-rendering: pixelated; }
+        button { margin-top: 10px; padding: 10px; font-size: 16px; }
+    </style>
+</head>
+<body>
+    <h1>Map Generation Debugger</h1>
+    <canvas id="debug-canvas"></canvas>
+    <button id="generate-btn">Generate New Map</button>
+    <script type="module" src="debug.js"></script>
+</body>
+</html>

--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,24 @@
+import { MapManager } from './src/map.js';
+
+const canvas = document.getElementById('debug-canvas');
+const ctx = canvas.getContext('2d');
+const generateBtn = document.getElementById('generate-btn');
+
+function drawMap() {
+    const mapManager = new MapManager();
+    const map = mapManager.map;
+    const tileSize = 10; // 디버그 캔버스에서는 타일을 작게 그림
+
+    canvas.width = mapManager.width * tileSize;
+    canvas.height = mapManager.height * tileSize;
+
+    for (let y = 0; y < mapManager.height; y++) {
+        for (let x = 0; x < mapManager.width; x++) {
+            ctx.fillStyle = (map[y][x] === mapManager.tileTypes.WALL) ? '#555' : 'white';
+            ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
+        }
+    }
+}
+
+generateBtn.onclick = drawMap;
+drawMap(); // 페이지 로드 시 첫 맵 생성

--- a/test.html
+++ b/test.html
@@ -23,5 +23,6 @@
     <script type="module" src="./tests/ai.test.js"></script>
 
     <script type="module" src="./tests/eventManager.integration.test.js"></script>
+    <script type="module" src="./tests/mapManager.test.js"></script>
     </body>
 </html>

--- a/tests/mapManager.test.js
+++ b/tests/mapManager.test.js
@@ -1,0 +1,59 @@
+import { MapManager } from '../src/map.js';
+
+console.log("--- Running MapManager Tests ---");
+
+try {
+    const mapManager = new MapManager();
+    const map = mapManager.map;
+    const { width, height } = mapManager;
+    const TILE_TYPES = mapManager.tileTypes;
+
+    // 테스트 1: 모든 복도와 방이 하나로 연결되어 있는가? (Flood Fill 알고리즘 사용)
+    let startNode = null;
+    let floorCount = 0;
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            if (map[y][x] === TILE_TYPES.FLOOR) {
+                if (!startNode) startNode = { x, y };
+                floorCount++;
+            }
+        }
+    }
+
+    if (startNode) {
+        const visited = new Set();
+        const queue = [startNode];
+        visited.add(`${startNode.x},${startNode.y}`);
+        let connectedCount = 0;
+
+        while (queue.length > 0) {
+            const current = queue.shift();
+            connectedCount++;
+            const { x, y } = current;
+            const neighbors = [
+                { x: x + 1, y: y },
+                { x: x - 1, y: y },
+                { x: x, y: y + 1 },
+                { x: x, y: y - 1 }
+            ];
+
+            for (const n of neighbors) {
+                const key = `${n.x},${n.y}`;
+                if (map[n.y] && map[n.y][n.x] === TILE_TYPES.FLOOR && !visited.has(key)) {
+                    visited.add(key);
+                    queue.push(n);
+                }
+            }
+        }
+
+        if (connectedCount !== floorCount) {
+            throw new Error(`맵이 고립된 공간을 포함합니다. 전체 바닥: ${floorCount}, 연결된 바닥: ${connectedCount}`);
+        }
+        console.log("✅ PASSED: 맵 연결성 테스트");
+    } else {
+        throw new Error("맵에 시작 지점을 찾을 수 없습니다.");
+    }
+
+} catch (e) {
+    console.error(`❌ FAILED: 맵 유효성 검사 - ${e.message}`);
+}


### PR DESCRIPTION
## Summary
- add a flood-fill based connectivity test for maps
- add debug page & script for visually inspecting maps
- update the web test runner to load the new test

## Testing
- `node tests/mapManager.test.js`
- `node tests/statManager.test.js && node tests/combatCalculator.test.js && node tests/random.test.js && node tests/pathfindingManager.test.js && node tests/turnManager.test.js && node tests/effectManager.test.js && node tests/ai.test.js && node tests/eventManager.integration.test.js && node tests/eventManager.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68528abb58488327a1e72366aed078e0