### PR TITLE
Fix monsterDeathWorkflow exp gain

### DIFF
--- a/src/workflows.js
+++ b/src/workflows.js
@@ -10,6 +10,12 @@ export function monsterDeathWorkflow(context) {
     // 2. "경험치 획득!" 이벤트를 방송한다.
     if (!victim.isFriendly && (attacker.isPlayer || attacker.isFriendly)) {
         const exp = victim.expValue;
+
+        // 실제 경험치를 즉시 적용하여 테스트에서도 검증 가능하도록 한다.
+        if (attacker.stats && typeof attacker.stats.addExp === 'function') {
+            attacker.stats.addExp(exp);
+        }
+
         eventManager.publish('exp_gained', { player: attacker, exp });
     }
     


### PR DESCRIPTION
## Summary
- award exp directly when monster dies

## Testing
- `node tests/workflows.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685294aa59788327b1042485750f23e8