### PR TITLE
Add npm test support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tile_crawler",
+  "version": "0.1.0",
+  "description": "Browser-based dungeon crawler",
+  "type": "module",
+  "scripts": {
+    "test": "node run-tests.mjs"
+  },
+  "license": "MIT"
+}

--- a/run-tests.mjs
+++ b/run-tests.mjs
@@ -1,0 +1,7 @@
+import { readdir } from 'fs/promises';
+
+const files = (await readdir('./tests')).filter(f => f.endsWith('.test.js')).sort();
+for (const file of files) {
+    console.log(`--- Running ${file} ---`);
+    await import(`./tests/${file}`);
+}


### PR DESCRIPTION
## Summary
- add `package.json` with npm test script
- include a simple `run-tests.mjs` to execute all test files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852957167f08327b31df478f1b4c5bd