### PR TITLE
Fix geometry.js import path

### DIFF
--- a/src/managers/fogManager.js
+++ b/src/managers/fogManager.js
@@ -1,6 +1,6 @@
 // src/fogManager.js
 
-import { hasLineOfSight } from './utils/geometry.js';
+import { hasLineOfSight } from '../utils/geometry.js';
 
 export const FOG_STATE = { UNSEEN: 0, SEEN: 1, VISIBLE: 2 };
 


### PR DESCRIPTION
## Summary
- correct import path in `FogManager` so browser loads geometry utils

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852a4be0bdc8327a32263b65c95f5d6