### PR TITLE
Implement tag-based combat system

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -1,29 +1,44 @@
-import { rollDiceNotation } from './utils/random.js';
-
 export class CombatCalculator {
-    constructor(eventManager) {
+    constructor(eventManager, tagManager) {
         this.eventManager = eventManager;
+        this.tagManager = tagManager;
     }
 
-    // 공격 이벤트를 처리하여 피해량을 계산한 뒤 이벤트로 발행한다.
     handleAttack(data) {
-        const { attacker, defender } = data;
+        const { attacker, defender, skill } = data;
 
-        const result = {};
+        let finalDamage = 0;
+        const details = { base: 0, fromSkill: 0, fromTags: 0, defenseReduction: 0 };
 
-        const weapon = attacker.equipment?.weapon;
-        const diceNotation = weapon && weapon.damageDice ? weapon.damageDice : '1d4';
-        result.diceRoll = rollDiceNotation(diceNotation);
-        result.statBonus = attacker.stats?.get('strength') || 0;
-        result.baseDamage = result.diceRoll + result.statBonus;
+        // 1. 기본 공격력 계산 (힘 기반)
+        details.base = attacker.attackPower;
+        finalDamage += details.base;
 
-        result.defenseReduction = defender.stats?.get('defense') || 0;
-        const finalDamage = Math.max(1, result.baseDamage - result.defenseReduction);
+        // 2. 스킬에 의한 데미지 계산
+        if (skill) {
+            if (this.tagManager.hasTag(skill, 'physical')) {
+                // 물리 스킬은 공격력 계수
+                details.fromSkill = (attacker.attackPower * (skill.damageMultiplier || 1)) - attacker.attackPower;
+            } else if (this.tagManager.hasTag(skill, 'magic')) {
+                // 마법 스킬은 지능 계수 (나중에 추가) + 기본 데미지
+                details.fromSkill = skill.damage || 0;
+            }
+            finalDamage += details.fromSkill;
 
-        this.eventManager.publish('damage_calculated', {
-            ...data,
-            damage: finalDamage,
-            details: { ...result, finalDamage },
-        });
+            // 3. 태그에 의한 추가 데미지 (미래를 위한 구멍)
+            const weapon = attacker.equipment.weapon;
+            if (this.tagManager.hasTag(weapon, 'fire_stone') && this.tagManager.hasTag(skill, 'fire')) {
+                details.fromTags = 5; // 화염석 보너스 +5
+                finalDamage += details.fromTags;
+            }
+        }
+
+        // 4. 방어력에 의한 피해 감소
+        details.defenseReduction = defender.stats.get('defense');
+        finalDamage = Math.max(1, finalDamage - details.defenseReduction);
+
+        details.finalDamage = finalDamage;
+
+        this.eventManager.publish('damage_calculated', { ...data, damage: finalDamage, details });
     }
 }

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -5,10 +5,10 @@ export const SKILLS = {
         description: '적에게 일반 공격보다 강력한 피해를 입힙니다.',
         manaCost: 10,
         cooldown: 120,
-        damageMultiplier: 2.5,
+        damageMultiplier: 2.0,
         damageDice: '1d8+2',
         icon: 'assets/images/fire-nova-effect.png',
-        tags: ['skill', 'attack', 'melee', 'single_target'],
+        tags: ['skill', 'attack', 'melee', 'physical'],
     },
     fireball: {
         id: 'fireball',

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -7,3 +7,4 @@ export { VFXManager } from './vfxManager.js';
 export { SkillManager } from './skillManager.js';
 export { SoundManager } from './soundManager.js';
 export { ProjectileManager } from './projectileManager.js';
+export { TagManager } from './tagManager.js';

--- a/src/managers/tagManager.js
+++ b/src/managers/tagManager.js
@@ -1,0 +1,15 @@
+export class TagManager {
+    constructor() {
+        console.log("[TagManager] Initialized");
+    }
+
+    /**
+     * 대상(아이템, 스킬 등)이 특정 태그를 가지고 있는지 확인합니다.
+     * @param {object} target - 검사할 대상 (item, skill 등)
+     * @param {string} tag - 확인할 태그
+     * @returns {boolean}
+     */
+    hasTag(target, tag) {
+        return target && Array.isArray(target.tags) && target.tags.includes(tag);
+    }
+}

--- a/tests/combatCalculator.test.js
+++ b/tests/combatCalculator.test.js
@@ -1,12 +1,14 @@
 import { CombatCalculator } from '../src/combat.js';
 import { EventManager } from '../src/managers/eventManager.js';
+import { TagManager } from '../src/managers/tagManager.js';
 import { test, assert } from './helpers.js';
 
 console.log("--- Running CombatCalculator Tests ---");
 
 test('피해량 계산 이벤트', () => {
     const eventManager = new EventManager();
-    const calculator = new CombatCalculator(eventManager);
+    const tagManager = new TagManager();
+    const calculator = new CombatCalculator(eventManager, tagManager);
     let eventData = null;
     eventManager.subscribe('damage_calculated', data => { eventData = data; });
 
@@ -14,12 +16,13 @@ test('피해량 계산 이벤트', () => {
     Math.random = () => 0; // deterministic roll
 
     const attacker = {
-        equipment: { weapon: { damageDice: '1d6' } },
-        stats: { get: (s) => (s === 'strength' ? 2 : 0) },
+        attackPower: 3,
+        equipment: { weapon: {} },
+        stats: { get: () => 0 },
     };
     const defender = { stats: { get: (s) => (s === 'defense' ? 1 : 0) } };
 
-    calculator.handleAttack({ attacker, defender });
+    calculator.handleAttack({ attacker, defender, skill: null });
 
     Math.random = originalRandom;
 


### PR DESCRIPTION
## Summary
- add TagManager for handling skill and item tags
- update skills with physical tag and tweak multiplier
- revise CombatCalculator to use TagManager
- create and wire TagManager in `Game`
- include skill information when attacking and adjust default attacks
- update exports and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852b3ccb324832797778462ef474b16