### PR TITLE
Fix missing skills import

### DIFF
--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -1,3 +1,5 @@
+import { SKILLS } from '../data/skills.js';
+
 export class UIManager {
     constructor() {
         this.levelElement = document.getElementById('ui-player-level');


### PR DESCRIPTION
## Summary
- import `SKILLS` in UI manager so skill icons load correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e026f8a08327be1c6f354cfe22fe