### PR TITLE
Bug fixes for mercenary and item management

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -118,6 +118,18 @@ export class Game {
         };
         this.playerGroup.addMember(player);
 
+        // 초기 아이템 배치
+        const potion = new Item(player.x + this.mapManager.tileSize,
+                                player.y,
+                                this.mapManager.tileSize,
+                                'potion', assets.potion);
+        const dagger = this.itemFactory.create('short_sword',
+                                player.x - this.mapManager.tileSize,
+                                player.y,
+                                this.mapManager.tileSize);
+        this.itemManager.addItem(potion);
+        if (dagger) this.itemManager.addItem(dagger);
+
         // === 3. 몬스터 생성 ===
         const monsters = [];
         for (let i = 0; i < 20; i++) {
@@ -344,8 +356,11 @@ export class Game {
             );
 
             if (clickedMerc) {
-                this.uiManager.showCharacterSheet(clickedMerc);
-                this.gameState.isPaused = true;
+                if (this.uiManager.showMercenaryDetail) {
+                    this.uiManager.showMercenaryDetail(clickedMerc);
+                    if (this.uiManager.mercDetailPanel)
+                        this.gameState.isPaused = true;
+                }
                 return; // 용병을 클릭했으면 더 이상 진행 안 함
             }
 

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -69,9 +69,11 @@ export class MetaAIManager {
                     targetX = next.x * tileSize;
                     targetY = next.y * tileSize;
                 } else {
-                    // pathfinding 실패 시 직접 목표 지점을 향해 이동 시도
                     targetX = action.target.x;
                     targetY = action.target.y;
+                    if (context.mapManager.isWallAt(targetX, targetY, entity.width, entity.height)) {
+                        break; // 이동 불가한 목표
+                    }
                 }
 
                 const dx = targetX - entity.x;

--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -5,6 +5,12 @@ export class MonsterManager {
         this.factory = factory;
         this.monsters = [];
         console.log("[MonsterManager] Initialized");
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('entity_removed', (data) => {
+                this.monsters = this.monsters.filter(m => m.id !== data.victimId);
+            });
+        }
     }
 
     getMonsterAt(x, y) {


### PR DESCRIPTION
## Summary
- remove dead monsters from monster manager
- pause only when mercenary detail panel exists
- spawn potion and dagger near player
- stop entities from shuddering at unreachable walls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e369583883278db432ad50c2c48d