### PR TITLE
Improve AI group controls

### DIFF
--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -36,7 +36,11 @@ export class MetaAIManager {
         return this.groups[id];
     }
     
-    setGroupStrategy(id, strategy) { /* ... */ }
+    setGroupStrategy(id, strategy) {
+        if (this.groups[id]) {
+            this.groups[id].strategy = strategy;
+        }
+    }
 
     executeAction(entity, action, context) {
         if (!action || !action.type || action.type === 'idle') return;
@@ -117,10 +121,12 @@ export class MetaAIManager {
             for (const member of [...group.members]) { // 복사본 순회!
                 if (member.hp <= 0) continue;
                 if (member.attackCooldown > 0) member.attackCooldown--;
-                if (member.ai) {
-                    const action = member.ai.decideAction(member, currentContext);
-                    this.executeAction(member, action, currentContext);
+
+                let action = { type: 'idle' };
+                if (group.strategy !== STRATEGY.IDLE && member.ai) {
+                    action = member.ai.decideAction(member, currentContext);
                 }
+                this.executeAction(member, action, currentContext);
             }
         }
     }

--- a/tests/aiGroupStrategy.test.js
+++ b/tests/aiGroupStrategy.test.js
@@ -1,0 +1,32 @@
+import { MetaAIManager, STRATEGY } from '../src/managers/ai-managers.js';
+import { MeleeAI } from '../src/ai.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { test, assert } from './helpers.js';
+
+console.log("--- Running AI Group Strategy Tests ---");
+
+test('setGroupStrategy updates strategy', () => {
+    const em = new EventManager();
+    const aiManager = new MetaAIManager(em);
+    const group = aiManager.createGroup('g1', STRATEGY.AGGRESSIVE);
+    aiManager.setGroupStrategy('g1', STRATEGY.IDLE);
+    assert.strictEqual(group.strategy, STRATEGY.IDLE);
+});
+
+test('IDLE strategy prevents movement', () => {
+    const em = new EventManager();
+    const aiManager = new MetaAIManager(em);
+    const mapManager = { tileSize: 1, isWallAt: () => false };
+    const pathfindingManager = { findPath: () => [{ x: 1, y: 0 }] };
+    const player = { x: 0, y: 0 };
+    const group = aiManager.createGroup('g1', STRATEGY.IDLE);
+    const enemyGroup = aiManager.createGroup('g2', STRATEGY.AGGRESSIVE);
+    const self = { id:'e1', x:0, y:0, width:1, height:1, speed:1, tileSize:1, attackCooldown:0, ai:new MeleeAI(), hp:1 };
+    const enemy = { id:'e2', x:1, y:0, width:1, height:1, speed:1, tileSize:1, attackCooldown:0, ai:new MeleeAI(), hp:1 };
+    group.addMember(self);
+    enemyGroup.addMember(enemy);
+    const context = { player, mapManager, pathfindingManager, eventManager: em };
+    aiManager.update(context);
+    assert.strictEqual(self.x, 0);
+    assert.strictEqual(self.y, 0);
+});

--- a/tests/aiUpdate.test.js
+++ b/tests/aiUpdate.test.js
@@ -1,0 +1,24 @@
+import { Mercenary, Item } from '../src/entities.js';
+import { EquipmentManager } from '../src/managers/equipmentManager.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { MeleeAI, RangedAI } from '../src/ai.js';
+import { test, assert } from './helpers.js';
+
+console.log("--- Running AI Update Tests ---");
+
+test('AI switches based on equipped weapon tags', () => {
+    const em = new EventManager();
+    const eqManager = new EquipmentManager(em);
+    const merc = new Mercenary({ x:0, y:0, tileSize:1, groupId:'g', stats:{} });
+    merc.ai = new MeleeAI();
+    const bow = new Item(0,0,1,'bow',null);
+    bow.tags = ['weapon','ranged'];
+    const sword = new Item(0,0,1,'sword',null);
+    sword.tags = ['weapon','melee'];
+
+    eqManager.equip(merc, bow, []);
+    assert.ok(merc.ai instanceof RangedAI);
+
+    eqManager.equip(merc, sword, []);
+    assert.ok(merc.ai instanceof MeleeAI);
+});


### PR DESCRIPTION
## Summary
- allow changing AI group strategies
- skip AI actions when strategy is IDLE
- add tests for group strategy control
- test automatic AI updates when equipping weapons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e8f8f87c8327b76adc13bb810b5a