### PR TITLE
Add mercenary skill logic

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -1,6 +1,7 @@
 // src/ai.js
 
 import { hasLineOfSight } from './utils/geometry.js';
+import { SKILLS } from './data/skills.js';
 
 // --- AI 유형(Archetype)의 기반이 될 부모 클래스 ---
 class AIArchetype {
@@ -40,7 +41,18 @@ export class MeleeAI extends AIArchetype {
                 mapManager
             );
             if (hasLOS && minDistance < self.attackRange) {
-                // 공격 범위 안에 있으면 공격
+                // 사용할 수 있는 스킬이 있다면 스킬 사용
+                const skillId = 'power_strike';
+                const skill = SKILLS[skillId];
+                if (
+                    self.skills && self.skills.includes(skillId) &&
+                    self.mp >= skill.manaCost &&
+                    (self.skillCooldowns[skillId] || 0) <= 0
+                ) {
+                    return { type: 'skill', target: nearestTarget, skillId };
+                }
+
+                // 공격 범위 안에 있으면 기본 공격
                 return { type: 'attack', target: nearestTarget };
             }
 

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -8,7 +8,8 @@ export const SKILLS = {
         damageMultiplier: 2.0,
         damageDice: '1d8+2',
         icon: 'assets/images/fire-nova-effect.png',
-        tags: ['skill', 'attack', 'melee', 'physical'],
+        range: 192,
+        tags: ['skill', 'attack', 'melee', 'physical', '근접', '물리', '단일'],
     },
     fireball: {
         id: 'fireball',
@@ -19,6 +20,7 @@ export const SKILLS = {
         damage: 10,
         damageDice: '1d10+3',
         projectile: 'fireball',
-        tags: ['skill', 'attack', 'magic', 'ranged', 'fire'],
+        range: 384,
+        tags: ['skill', 'attack', 'magic', 'ranged', 'fire', '마법', '화염', '단일'],
     },
 };

--- a/src/game.js
+++ b/src/game.js
@@ -266,7 +266,8 @@ export class Game {
             eventManager.publish('log', { message: `${caster.constructor.name} (이)가 ${skill.name} 스킬 사용!`, color: 'aqua' });
 
             if (skill.tags.includes('attack')) {
-                const nearestEnemy = this.findNearestEnemy(caster, monsterManager.monsters);
+                const range = skill.range || Infinity;
+                const nearestEnemy = this.findNearestEnemy(caster, monsterManager.monsters, range);
                 if (nearestEnemy) {
                     if (skill.projectile) {
                         this.projectileManager.create(caster, nearestEnemy, skill);
@@ -368,14 +369,14 @@ export class Game {
         });
     }
 
-    findNearestEnemy(caster, enemies) {
+    findNearestEnemy(caster, enemies, range = Infinity) {
         let nearest = null;
         let minDist = Infinity;
         for (const enemy of enemies) {
             const dx = enemy.x - caster.x;
             const dy = enemy.y - caster.y;
             const dist = Math.hypot(dx, dy);
-            if (dist < minDist) {
+            if (dist < minDist && dist <= range) {
                 minDist = dist;
                 nearest = enemy;
             }

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -1,4 +1,5 @@
 // src/ai-managers.js
+import { SKILLS } from '../data/skills.js';
 
 export const STRATEGY = {
     IDLE: 'idle',
@@ -57,6 +58,19 @@ export class MetaAIManager {
                 if (entity.attackCooldown === 0) {
                     // 공격 이벤트를 발행
                     eventManager.publish('entity_attack', { attacker: entity, defender: action.target });
+                    entity.attackCooldown = 60;
+                }
+                break;
+            case 'skill':
+                const skill = SKILLS[action.skillId];
+                if (
+                    skill &&
+                    entity.mp >= skill.manaCost &&
+                    (entity.skillCooldowns[action.skillId] || 0) <= 0
+                ) {
+                    entity.mp -= skill.manaCost;
+                    entity.skillCooldowns[action.skillId] = skill.cooldown;
+                    eventManager.publish('skill_used', { caster: entity, skill });
                     entity.attackCooldown = 60;
                 }
                 break;


### PR DESCRIPTION
## Summary
- add Korean tags and range info to skills
- allow AI mercenaries to cast Power Strike
- handle skill actions in MetaAIManager
- respect skill range when picking targets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ee2205308327a22254e756bc99e7