### PR TITLE
Improve pathfinding by considering entity collisions

### DIFF
--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -80,7 +80,26 @@ export class MetaAIManager {
                 const startY = Math.floor(entity.y / tileSize);
                 const endX = Math.floor(action.target.x / tileSize);
                 const endY = Math.floor(action.target.y / tileSize);
-                const path = context.pathfindingManager.findPath(startX, startY, endX, endY);
+
+                const allEntities = [
+                    context.player,
+                    ...context.monsterManager.monsters,
+                    ...context.mercenaryManager.mercenaries
+                ];
+                const isBlocked = (x, y) => {
+                    for (const e of allEntities) {
+                        if (e === entity) continue;
+                        const ex = Math.floor(e.x / tileSize);
+                        const ey = Math.floor(e.y / tileSize);
+                        if (ex === x && ey === y) {
+                            if (x === endX && y === endY) return false;
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+
+                const path = context.pathfindingManager.findPath(startX, startY, endX, endY, isBlocked);
                 let targetX, targetY;
                 if (path.length > 0) {
                     const next = path[0];

--- a/src/managers/pathfindingManager.js
+++ b/src/managers/pathfindingManager.js
@@ -5,7 +5,7 @@ export class PathfindingManager {
         this.mapManager = mapManager;
     }
 
-    _bfs(startX, startY, endX, endY) {
+    _bfs(startX, startY, endX, endY, isBlocked) {
         const { map, width, height, tileTypes } = this.mapManager;
 
         if (startX === endX && startY === endY) return [];
@@ -42,6 +42,7 @@ export class PathfindingManager {
 
                 if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
                 if (map[ny][nx] === tileTypes.WALL) continue;
+                if (isBlocked(nx, ny) && !(nx === endX && ny === endY)) continue;
                 if (visited.has(nKey)) continue;
 
                 visited.add(nKey);
@@ -54,10 +55,10 @@ export class PathfindingManager {
     }
 
     // 타겟 주변의 이동 가능한 위치까지 경로를 찾는다.
-    findPath(startX, startY, endX, endY) {
+    findPath(startX, startY, endX, endY, isBlocked = () => false) {
         console.log(`Pathfinding from (${startX},${startY}) to (${endX},${endY})`);
 
-        const basePath = this._bfs(startX, startY, endX, endY);
+        const basePath = this._bfs(startX, startY, endX, endY, isBlocked);
         if (basePath.length > 0) return basePath;
 
         const { map, width, height, tileTypes } = this.mapManager;
@@ -71,7 +72,7 @@ export class PathfindingManager {
             const ny = endY + dir.y;
             if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
             if (map[ny][nx] === tileTypes.WALL) continue;
-            const path = this._bfs(startX, startY, nx, ny);
+            const path = this._bfs(startX, startY, nx, ny, isBlocked);
             if (path.length > 0 && (bestPath.length === 0 || path.length < bestPath.length)) {
                 bestPath = path;
             }

--- a/tests/pathfindingManager.test.js
+++ b/tests/pathfindingManager.test.js
@@ -28,3 +28,30 @@ test('단순 경로 탐색', () => {
     const path = pfManager.findPath(0,0,2,0);
     assert.deepStrictEqual(path, [{x:1,y:0},{x:2,y:0}]);
 });
+
+test('동적 장애물 회피', () => {
+    const mapManager = {
+        map: [
+            [0,0,0],
+            [0,0,0],
+            [0,0,0]
+        ],
+        width:3,
+        height:3,
+        tileSize:1,
+        tileTypes:{FLOOR:0,WALL:1},
+        isWallAt(x,y){
+            const tx=Math.floor(x/1); const ty=Math.floor(y/1);
+            return this.map[ty][tx]===this.tileTypes.WALL;
+        }
+    };
+    const pfManager = new PathfindingManager(mapManager);
+    const blocker = (x,y)=> (x===1 && y===0);
+    const path = pfManager.findPath(0,0,2,0,blocker);
+    assert.deepStrictEqual(path, [
+        {x:0,y:1},
+        {x:1,y:1},
+        {x:2,y:1},
+        {x:2,y:0}
+    ]);
+});


### PR DESCRIPTION
## Summary
- allow the pathfinding manager to accept a custom blockage callback
- make AI movement avoid tiles occupied by other units
- add a unit test for entity-blocking pathfinding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685301d2989c8327a95d6206313ec990