### PR TITLE
Implement warrior mercenary skills

### DIFF
--- a/skills.md
+++ b/skills.md
@@ -33,3 +33,8 @@
 | spell_weakness | 마법 취약 | debuff, magic_resist_down |
 | elemental_weakness | 원소 취약 | debuff, resist_down |
 
+### 스킬 비고
+
+- **이중 타격**: 한 번의 명령으로 두 차례 공격합니다.
+- **돌진 공격**: 지정된 거리만큼 적에게 돌진한 뒤 공격을 가합니다.
+

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -33,6 +33,8 @@ export const SKILLS = {
         description: '대시하여 적을 강하게 공격합니다.',
         manaCost: 8,
         cooldown: 180,
+        damageMultiplier: 1.5,
+        dashRange: 4,
         tags: ['skill', 'attack', 'melee', 'physical', 'dash', '근접', '물리'],
     },
     double_strike: {
@@ -41,6 +43,7 @@ export const SKILLS = {
         description: '두 번의 근접 공격을 빠르게 가합니다.',
         manaCost: 12,
         cooldown: 120,
+        hits: 2,
         tags: ['skill', 'attack', 'melee', 'physical', 'multi-hit', '근접', '물리'],
     },
     double_thrust: {

--- a/src/factory.js
+++ b/src/factory.js
@@ -54,7 +54,10 @@ export class CharacterFactory {
                 if (config.jobId && JOBS[config.jobId]) {
                     finalConfig.stats = { ...finalConfig.stats, ...JOBS[config.jobId].stats };
                 }
-                return new Mercenary(finalConfig);
+                const merc = new Mercenary(finalConfig);
+                const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
+                merc.skills.push(skillId);
+                return merc;
             case 'monster':
                 return new Monster(finalConfig);
         }

--- a/src/game.js
+++ b/src/game.js
@@ -79,6 +79,7 @@ export class Game {
 
         this.itemFactory = new ItemFactory(assets);
         this.pathfindingManager = new PathfindingManager(this.mapManager);
+        this.motionManager = new Managers.MotionManager(this.mapManager, this.pathfindingManager);
         this.fogManager = new FogManager(this.mapManager.width, this.mapManager.height);
         // UIManager가 mercenaryManager에 접근할 수 있도록 설정
         this.uiManager.mercenaryManager = this.mercenaryManager;
@@ -269,10 +270,16 @@ export class Game {
                 const range = skill.range || Infinity;
                 const nearestEnemy = this.findNearestEnemy(caster, monsterManager.monsters, range);
                 if (nearestEnemy) {
-                    if (skill.projectile) {
-                        this.projectileManager.create(caster, nearestEnemy, skill);
-                    } else {
-                        eventManager.publish('entity_attack', { attacker: caster, defender: nearestEnemy, skill: skill });
+                    if (skill.dashRange) {
+                        this.motionManager.dashTowards(caster, nearestEnemy, skill.dashRange);
+                    }
+                    const hits = skill.hits || 1;
+                    for (let i = 0; i < hits; i++) {
+                        if (skill.projectile) {
+                            this.projectileManager.create(caster, nearestEnemy, skill);
+                        } else {
+                            eventManager.publish('entity_attack', { attacker: caster, defender: nearestEnemy, skill: skill });
+                        }
                     }
                 } else {
                     eventManager.publish('log', { message: '시야에 대상이 없습니다.' });

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -11,6 +11,7 @@ import { SkillManager } from './skillManager.js';
 import { SoundManager } from './soundManager.js';
 import { EffectManager } from './effectManager.js';
 import { ProjectileManager } from './projectileManager.js';
+import { MotionManager } from './motionManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
 
 export {
@@ -24,4 +25,5 @@ export {
     SoundManager,
     EffectManager,
     ProjectileManager,
+    MotionManager,
 };

--- a/src/managers/motionManager.js
+++ b/src/managers/motionManager.js
@@ -1,0 +1,28 @@
+export class MotionManager {
+    constructor(mapManager, pathfindingManager) {
+        this.mapManager = mapManager;
+        this.pathfindingManager = pathfindingManager;
+        console.log("[MotionManager] Initialized");
+    }
+
+    dashTowards(entity, target, maxTiles = 1) {
+        const tileSize = this.mapManager.tileSize;
+        const startX = Math.floor(entity.x / tileSize);
+        const startY = Math.floor(entity.y / tileSize);
+        const endX = Math.floor(target.x / tileSize);
+        const endY = Math.floor(target.y / tileSize);
+
+        const path = this.pathfindingManager.findPath(startX, startY, endX, endY, () => false);
+        if (path.length < 2) return;
+
+        const stepIndex = Math.min(maxTiles, path.length - 2);
+        const dest = path[stepIndex];
+        const destX = dest.x * tileSize;
+        const destY = dest.y * tileSize;
+
+        if (!this.mapManager.isWallAt(destX, destY, entity.width, entity.height)) {
+            entity.x = destX;
+            entity.y = destY;
+        }
+    }
+}

--- a/tests/mercenarySkills.test.js
+++ b/tests/mercenarySkills.test.js
@@ -1,0 +1,26 @@
+import { CharacterFactory } from '../src/factory.js';
+import { test, assert } from './helpers.js';
+import { SKILLS } from '../src/data/skills.js';
+
+console.log("--- Running Mercenary Skill Tests ---");
+
+const assets = { mercenary:{} };
+
+function createMercWithRandom(randomValue) {
+    const original = Math.random;
+    Math.random = () => randomValue;
+    const factory = new CharacterFactory(assets);
+    const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'warrior', image:null });
+    Math.random = original;
+    return merc;
+}
+
+test('무작위 스킬 부여 - double_strike', () => {
+    const merc = createMercWithRandom(0.1);
+    assert.strictEqual(merc.skills[0], SKILLS.double_strike.id);
+});
+
+test('무작위 스킬 부여 - charge_attack', () => {
+    const merc = createMercWithRandom(0.9);
+    assert.strictEqual(merc.skills[0], SKILLS.charge_attack.id);
+});

--- a/tests/motionManager.test.js
+++ b/tests/motionManager.test.js
@@ -1,0 +1,23 @@
+import { PathfindingManager } from '../src/managers/pathfindingManager.js';
+import { MotionManager } from '../src/managers/motionManager.js';
+import { test, assert } from './helpers.js';
+
+console.log("--- Running MotionManager Tests ---");
+
+test('dashTowards 이동 거리 제한', () => {
+    const mapManager = {
+        tileSize: 1,
+        width: 5,
+        height: 5,
+        tileTypes: { FLOOR: 0, WALL: 1 },
+        map: Array.from({ length: 5 }, () => Array(5).fill(0)),
+        isWallAt: () => false,
+    };
+    const pathManager = new PathfindingManager(mapManager);
+    const motion = new MotionManager(mapManager, pathManager);
+    const entity = { x: 0, y: 0, width: 1, height: 1 };
+    const target = { x: 4, y: 0 };
+    motion.dashTowards(entity, target, 3);
+    assert.strictEqual(entity.x, 3);
+    assert.strictEqual(entity.y, 0);
+});


### PR DESCRIPTION
## Summary
- define a `MotionManager` for dash-style movement
- give hired mercenaries either `double_strike` or `charge_attack`
- expand skill data for extra hits and dash
- execute skill hits and dash in `Game` event listener
- document new skill behavior
- add tests for mercenary skill rolls and motion manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853059a37a483279e15f814b2c6340b