### PR TITLE
Add archer mercenary and ranged AI

### DIFF
--- a/src/data/jobs.js
+++ b/src/data/jobs.js
@@ -11,6 +11,18 @@ export const JOBS = {
             attackPower: 17,
         }
     },
-    // 나중에 여기에 'archer', 'healer' 등을 추가
+    archer: {
+        name: '궁수',
+        description: '원거리에서 활을 다루는 전문가입니다.',
+        stats: {
+            strength: 5,
+            agility: 8,
+            endurance: 4,
+            movement: 10,
+            hp: 30,
+            attackPower: 15,
+        }
+    },
+    // 나중에 여기에 'healer' 등을 추가
 };
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -8,6 +8,7 @@ import { ITEMS } from './data/items.js';
 import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
+import { RangedAI } from './ai.js';
 
 export class CharacterFactory {
     constructor(assets) {
@@ -55,8 +56,17 @@ export class CharacterFactory {
                     finalConfig.stats = { ...finalConfig.stats, ...JOBS[config.jobId].stats };
                 }
                 const merc = new Mercenary(finalConfig);
-                const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
-                merc.skills.push(skillId);
+
+                if (config.jobId === 'archer') {
+                    const rangedSkill = Math.random() < 0.5 ? SKILLS.double_thrust.id : SKILLS.hawk_eye.id;
+                    merc.skills.push(rangedSkill);
+                    merc.equipment.weapon = { tags: ['weapon', 'ranged', 'bow'] };
+                    merc.ai = new RangedAI();
+                } else {
+                    const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
+                    merc.skills.push(skillId);
+                }
+
                 return merc;
             case 'monster':
                 return new Monster(finalConfig);

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -1,4 +1,4 @@
-import { MeleeAI } from '../src/ai.js';
+import { MeleeAI, RangedAI } from '../src/ai.js';
 import { test, assert } from './helpers.js';
 
 console.log("--- Running AI Tests ---");
@@ -35,4 +35,25 @@ test('MeleeAI - 플레이어 추적', () => {
     const action = ai.decideAction(self, context);
     assert.strictEqual(action.type, 'move');
     assert.strictEqual(action.target, player);
+});
+
+// RangedAI specific behavior
+test('RangedAI - 가까운 적에게서 거리 벌림', () => {
+    const ai = new RangedAI();
+    const self = { x: 0, y: 0, visionRange: 100, attackRange: 20, speed: 5, tileSize: 1 };
+    const enemy = { x: 5, y: 0 };
+    const context = { player: {}, allies: [], enemies: [enemy], mapManager: mapStub };
+    const action = ai.decideAction(self, context);
+    assert.strictEqual(action.type, 'move');
+    assert.ok(action.target.x < self.x);
+});
+
+test('RangedAI - 사정거리 밖 적에게 접근', () => {
+    const ai = new RangedAI();
+    const self = { x: 0, y: 0, visionRange: 100, attackRange: 20, speed: 5, tileSize: 1 };
+    const enemy = { x: 50, y: 0 };
+    const context = { player: {}, allies: [], enemies: [enemy], mapManager: mapStub };
+    const action = ai.decideAction(self, context);
+    assert.strictEqual(action.type, 'move');
+    assert.strictEqual(action.target, enemy);
 });

--- a/tests/mercenarySkills.test.js
+++ b/tests/mercenarySkills.test.js
@@ -6,11 +6,11 @@ console.log("--- Running Mercenary Skill Tests ---");
 
 const assets = { mercenary:{} };
 
-function createMercWithRandom(randomValue) {
+function createMercWithRandom(randomValue, jobId = 'warrior') {
     const original = Math.random;
     Math.random = () => randomValue;
     const factory = new CharacterFactory(assets);
-    const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'warrior', image:null });
+    const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId, image:null });
     Math.random = original;
     return merc;
 }
@@ -23,4 +23,14 @@ test('무작위 스킬 부여 - double_strike', () => {
 test('무작위 스킬 부여 - charge_attack', () => {
     const merc = createMercWithRandom(0.9);
     assert.strictEqual(merc.skills[0], SKILLS.charge_attack.id);
+});
+
+test('궁수 스킬 부여 - double_thrust', () => {
+    const merc = createMercWithRandom(0.1, 'archer');
+    assert.strictEqual(merc.skills[0], SKILLS.double_thrust.id);
+});
+
+test('궁수 스킬 부여 - hawk_eye', () => {
+    const merc = createMercWithRandom(0.9, 'archer');
+    assert.strictEqual(merc.skills[0], SKILLS.hawk_eye.id);
 });


### PR DESCRIPTION
## Summary
- implement RangedAI for kiting behavior
- add archer job data
- create archer mercenaries with bow and random ranged skill
- expand tests for archer skills and ranged AI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685309b113508327b6ba45906eb3b0f6