### PR TITLE
Add hire archer button

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
             </div>
             <div id="mercenary-controls">
                 <button id="hire-mercenary">전사 용병 고용 (50골드)</button>
+                <button id="hire-archer">궁수 용병 고용 (50골드)</button>
                 <button id="save-game-btn">게임 저장</button>
             </div>
         </div>

--- a/src/game.js
+++ b/src/game.js
@@ -174,6 +174,29 @@ export class Game {
             };
         }
 
+        const archerBtn = document.getElementById('hire-archer');
+        if (archerBtn) {
+            archerBtn.onclick = () => {
+                if (this.gameState.gold >= 50) {
+                    this.gameState.gold -= 50;
+                    const newMerc = this.mercenaryManager.hireMercenary(
+                        'archer',
+                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.y,
+                        this.mapManager.tileSize,
+                        'player_party'
+                    );
+
+                    if (newMerc) {
+                        this.playerGroup.addMember(newMerc);
+                        this.eventManager.publish('log', { message: `궁수 용병을 고용했습니다.` });
+                    }
+                } else {
+                    this.eventManager.publish('log', { message: `골드가 부족합니다.` });
+                }
+            };
+        }
+
         const saveBtn = document.getElementById('save-game-btn');
         if (saveBtn) {
             saveBtn.onclick = () => {

--- a/tests/microSmoke.test.js
+++ b/tests/microSmoke.test.js
@@ -23,6 +23,9 @@ test('간단한 게임 흐름', () => {
     const merc = mercManager.hireMercenary('warrior', 1, 0, 1, 'player_party');
     assert.ok(merc, '용병 고용');
 
+    const archer = mercManager.hireMercenary('archer', 2, 0, 1, 'player_party');
+    assert.ok(archer && archer.ai, '궁수 용병 고용');
+
     const monster = factory.create('monster', { x:2, y:0, tileSize:1, groupId:'dungeon_monsters', baseStats:{ expValue:5 } });
     let expEvent = false;
     eventManager.subscribe('exp_gained', () => { expEvent = true; });


### PR DESCRIPTION
## Summary
- add a button in the UI for hiring archer mercenaries
- implement archer hiring logic in `Game`
- extend micro smoke test to hire an archer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68530b56f7548327b8943d04ea75d4c4