### PR TITLE
Add iceball skill projectile and strike VFX

### DIFF
--- a/VFX_GUIDE.md
+++ b/VFX_GUIDE.md
@@ -1,0 +1,18 @@
+# VFX 시스템 가이드
+
+이 문서는 게임 내 시각 효과(VFX)를 어떻게 다루는지 간략하게 설명합니다.
+
+## VFXManager 역할
+- `VFXManager`는 파티클과 스프라이트 효과를 관리합니다.
+- `addGlow(x, y, options)` : 이동하는 투사체의 잔광 등을 만듭니다.
+- `addSpriteEffect(image, x, y, options)` : 특정 위치에 잠깐 표시되는 이미지 효과를 추가합니다.
+
+## 기본 공격 스트라이크 이펙트
+- 파일: `assets/images/strike-effect.png`
+- `entity_attack` 이벤트가 발생할 때 스킬에 투사체가 없다면 해당 이펙트를 대상 위에 덮어씌웁니다.
+- 밝은 합성(`lighter`)으로 그려지며 짧은 시간 후 사라집니다.
+
+## 아이스볼 투사체
+- 파일: `assets/images/ice-ball-effect.png`
+- `iceball` 스킬의 투사체 이미지로 사용됩니다.
+- 파이어볼과 동일하게 이동 중 파티클 잔광이 생성됩니다.

--- a/src/factory.js
+++ b/src/factory.js
@@ -50,6 +50,7 @@ export class CharacterFactory {
             case 'player':
                 const player = new Player(finalConfig);
                 player.skills.push(SKILLS.fireball.id);
+                player.skills.push(SKILLS.iceball.id);
                 return player;
             case 'mercenary':
                 if (config.jobId && JOBS[config.jobId]) {

--- a/src/game.js
+++ b/src/game.js
@@ -39,6 +39,8 @@ export class Game {
         this.loader.loadImage('bow', 'assets/images/bow.png');
         this.loader.loadImage('leather_armor', 'assets/images/leatherarmor.png');
         this.loader.loadImage('fire-ball', 'assets/images/fire-ball.png');
+        this.loader.loadImage('ice-ball', 'assets/images/ice-ball-effect.png');
+        this.loader.loadImage('strike-effect', 'assets/images/strike-effect.png');
 
         this.loader.onReady(assets => this.init(assets));
     }
@@ -239,6 +241,19 @@ export class Game {
         // 공격 이벤트가 발생하면 CombatCalculator에 계산을 요청
         eventManager.subscribe('entity_attack', (data) => {
             combatCalculator.handleAttack(data);
+
+            const { attacker, defender, skill } = data;
+            if (!skill || !skill.projectile) {
+                const img = assets['strike-effect'];
+                if (img) {
+                    this.vfxManager.addSpriteEffect(
+                        img,
+                        defender.x + defender.width / 2,
+                        defender.y + defender.height / 2,
+                        { width: defender.width, height: defender.height }
+                    );
+                }
+            }
         });
 
         // 피해량 계산 완료 이벤트를 받아 실제 피해 적용

--- a/src/managers/projectileManager.js
+++ b/src/managers/projectileManager.js
@@ -10,7 +10,11 @@ export class ProjectileManager {
     }
 
     create(caster, target, skill) {
-        const imageKey = skill.projectile === 'fireball' ? 'fire-ball' : skill.projectile;
+        const keyMap = {
+            fireball: 'fire-ball',
+            iceball: 'ice-ball'
+        };
+        const imageKey = keyMap[skill.projectile] || skill.projectile;
 
         const config = {
             x: caster.x,

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -25,13 +25,46 @@ export class VFXManager {
         this.effects.push(effect);
     }
 
+    /**
+     * 이미지 스프라이트 이펙트를 추가합니다.
+     * 대상 위치에 밝게 표시되며 일정 시간 후 사라집니다.
+     * @param {HTMLImageElement} image
+     * @param {number} x
+     * @param {number} y
+     * @param {object} [options]
+     */
+    addSpriteEffect(image, x, y, options = {}) {
+        const effect = {
+            type: 'sprite',
+            image,
+            x,
+            y,
+            width: options.width || image.width,
+            height: options.height || image.height,
+            duration: options.duration || 20,
+            alpha: options.alpha || 1.0,
+            fade: options.fade || 0.05,
+            blendMode: options.blendMode || 'lighter',
+        };
+        this.effects.push(effect);
+    }
+
     update() {
-        this.effects.forEach((effect, index) => {
-            effect.alpha -= effect.decay;
-            if (effect.alpha <= 0) {
-                this.effects.splice(index, 1);
+        for (let i = this.effects.length - 1; i >= 0; i--) {
+            const effect = this.effects[i];
+            if (effect.type === 'glow') {
+                effect.alpha -= effect.decay;
+                if (effect.alpha <= 0) {
+                    this.effects.splice(i, 1);
+                }
+            } else if (effect.type === 'sprite') {
+                effect.duration--;
+                effect.alpha -= effect.fade;
+                if (effect.duration <= 0 || effect.alpha <= 0) {
+                    this.effects.splice(i, 1);
+                }
             }
-        });
+        }
     }
 
     render(ctx) {
@@ -48,6 +81,18 @@ export class VFXManager {
                 ctx.arc(x, y, radius, 0, Math.PI * 2);
                 ctx.fillStyle = gradient;
                 ctx.fill();
+                ctx.restore();
+            } else if (effect.type === 'sprite') {
+                ctx.save();
+                ctx.globalCompositeOperation = effect.blendMode;
+                ctx.globalAlpha = effect.alpha;
+                ctx.drawImage(
+                    effect.image,
+                    effect.x - effect.width / 2,
+                    effect.y - effect.height / 2,
+                    effect.width,
+                    effect.height
+                );
                 ctx.restore();
             }
         }


### PR DESCRIPTION
## Summary
- load new assets for ice-ball and strike-effect
- enable player to start with the iceball skill
- handle melee attack visuals with strike-effect via VFXManager
- map iceball projectile image in ProjectileManager
- expand VFXManager with sprite effects
- document the VFX system

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853108b6f1c8327ae8c19d1e409f81e