### PR TITLE
Add red flash damage VFX

### DIFF
--- a/VFX_GUIDE.md
+++ b/VFX_GUIDE.md
@@ -6,6 +6,7 @@
 - `VFXManager`는 파티클과 스프라이트 효과를 관리합니다.
 - `addGlow(x, y, options)` : 이동하는 투사체의 잔광 등을 만듭니다.
 - `addSpriteEffect(image, x, y, options)` : 특정 위치에 잠깐 표시되는 이미지 효과를 추가합니다.
+- `flashEntity(entity, options)` : 대상 스프라이트를 잠깐 특정 색으로 덮어써 반짝이는 효과를 만듭니다.
 
 ## 기본 공격 스트라이크 이펙트
 - 파일: `assets/images/strike-effect.png`
@@ -16,3 +17,7 @@
 - 파일: `assets/images/ice-ball-effect.png`
 - `iceball` 스킬의 투사체 이미지로 사용됩니다.
 - 파이어볼과 동일하게 이동 중 파티클 잔광이 생성됩니다.
+
+## 피격 시 빨간 플래시
+- `entity_damaged` 이벤트가 발생하면 `flashEntity`가 호출되어 피해를 받은 유닛의 스프라이트를 잠깐 빨갛게 덮어씁니다.
+- 기본 지속 시간은 약 6프레임이며, 필요하면 옵션으로 조절할 수 있습니다.

--- a/src/game.js
+++ b/src/game.js
@@ -259,10 +259,15 @@ export class Game {
         // 피해량 계산 완료 이벤트를 받아 실제 피해 적용
         eventManager.subscribe('damage_calculated', (data) => {
             data.defender.takeDamage(data.damage);
+            eventManager.publish('entity_damaged', { attacker: data.attacker, defender: data.defender, damage: data.damage });
             if (data.defender.hp <= 0) {
                 eventManager.publish('entity_death', { attacker: data.attacker, victim: data.defender });
                 eventManager.publish('entity_removed', { victimId: data.defender.id });
             }
+        });
+
+        eventManager.subscribe('entity_damaged', (data) => {
+            this.vfxManager.flashEntity(data.defender);
         });
 
         // 죽음 이벤트가 발생하면 경험치 이벤트를 발행

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -49,6 +49,21 @@ export class VFXManager {
         this.effects.push(effect);
     }
 
+    /**
+     * 대상 엔티티 이미지를 잠깐 색상으로 덮어씌워 번쩍이는 효과를 줍니다.
+     * @param {object} entity - Entity instance (player, monster 등)
+     * @param {object} [options]
+     */
+    flashEntity(entity, options = {}) {
+        const effect = {
+            type: 'flash',
+            entity,
+            duration: options.duration || 6,
+            color: options.color || 'rgba(255,0,0,0.5)'
+        };
+        this.effects.push(effect);
+    }
+
     update() {
         for (let i = this.effects.length - 1; i >= 0; i--) {
             const effect = this.effects[i];
@@ -61,6 +76,11 @@ export class VFXManager {
                 effect.duration--;
                 effect.alpha -= effect.fade;
                 if (effect.duration <= 0 || effect.alpha <= 0) {
+                    this.effects.splice(i, 1);
+                }
+            } else if (effect.type === 'flash') {
+                effect.duration--;
+                if (effect.duration <= 0) {
                     this.effects.splice(i, 1);
                 }
             }
@@ -93,6 +113,14 @@ export class VFXManager {
                     effect.width,
                     effect.height
                 );
+                ctx.restore();
+            } else if (effect.type === 'flash') {
+                const { entity } = effect;
+                ctx.save();
+                ctx.drawImage(entity.image, entity.x, entity.y, entity.width, entity.height);
+                ctx.globalCompositeOperation = 'source-atop';
+                ctx.fillStyle = effect.color;
+                ctx.fillRect(entity.x, entity.y, entity.width, entity.height);
                 ctx.restore();
             }
         }


### PR DESCRIPTION
## Summary
- support sprite flash VFX with `flashEntity`
- trigger `entity_damaged` when damage is applied
- flash damaged entity red via event listener
- document flash effect in `VFX_GUIDE`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853128787fc8327beab75c6d70135fb