### PR TITLE
Add screen blend strike effect and particles

### DIFF
--- a/VFX_GUIDE.md
+++ b/VFX_GUIDE.md
@@ -11,7 +11,7 @@
 ## 기본 공격 스트라이크 이펙트
 - 파일: `assets/images/strike-effect.png`
 - `entity_attack` 이벤트가 발생할 때 스킬에 투사체가 없다면 해당 이펙트를 대상 위에 덮어씌웁니다.
-- 밝은 합성(`lighter`)으로 그려지며 짧은 시간 후 사라집니다.
+- 이미지는 `screen` 블렌드 모드로 표시되고, 동시에 작은 파티클이 퍼져나갑니다.
 
 ## 아이스볼 투사체
 - 파일: `assets/images/ice-ball-effect.png`

--- a/src/game.js
+++ b/src/game.js
@@ -250,7 +250,16 @@ export class Game {
                         img,
                         defender.x + defender.width / 2,
                         defender.y + defender.height / 2,
-                        { width: defender.width, height: defender.height }
+                        {
+                            width: defender.width,
+                            height: defender.height,
+                            blendMode: 'screen'
+                        }
+                    );
+                    this.vfxManager.addParticleBurst(
+                        defender.x + defender.width / 2,
+                        defender.y + defender.height / 2,
+                        { color: 'orange', count: 12 }
                     );
                 }
             }

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -1,6 +1,9 @@
+import { Particle } from '../particle.js';
+
 export class VFXManager {
     constructor() {
         this.effects = [];
+        this.particles = [];
         console.log("[VFXManager] Initialized");
     }
 
@@ -23,6 +26,20 @@ export class VFXManager {
             blendMode: 'lighter',
         };
         this.effects.push(effect);
+    }
+
+    /**
+     * 작은 사각형 파티클 여러 개를 한 번에 생성합니다.
+     * @param {number} x
+     * @param {number} y
+     * @param {object} [options]
+     */
+    addParticleBurst(x, y, options = {}) {
+        const count = options.count || 8;
+        const color = options.color || 'yellow';
+        for (let i = 0; i < count; i++) {
+            this.particles.push(new Particle(x, y, color));
+        }
     }
 
     /**
@@ -85,6 +102,14 @@ export class VFXManager {
                 }
             }
         }
+
+        for (let i = this.particles.length - 1; i >= 0; i--) {
+            const p = this.particles[i];
+            p.update();
+            if (p.lifespan <= 0) {
+                this.particles.splice(i, 1);
+            }
+        }
     }
 
     render(ctx) {
@@ -124,5 +149,10 @@ export class VFXManager {
                 ctx.restore();
             }
         }
+
+        for (const p of this.particles) {
+            p.render(ctx);
+        }
     }
 }
+

--- a/src/particle.js
+++ b/src/particle.js
@@ -1,0 +1,28 @@
+export class Particle {
+    constructor(x, y, color) {
+        this.x = x;
+        this.y = y;
+        this.color = color;
+        const angle = Math.random() * Math.PI * 2;
+        const speed = Math.random() * 3 + 1;
+        this.vx = Math.cos(angle) * speed;
+        this.vy = Math.sin(angle) * speed;
+        this.gravity = 0.1;
+        this.lifespan = 60 + Math.random() * 30;
+        this.size = Math.random() * 3 + 1;
+    }
+
+    update() {
+        this.lifespan--;
+        this.vy += this.gravity;
+        this.x += this.vx;
+        this.y += this.vy;
+    }
+
+    render(ctx) {
+        ctx.fillStyle = this.color;
+        ctx.globalAlpha = this.lifespan / 60;
+        ctx.fillRect(this.x, this.y, this.size, this.size);
+        ctx.globalAlpha = 1.0;
+    }
+}


### PR DESCRIPTION
## Summary
- draw the melee strike effect using `screen` blend mode
- spawn a burst of particles around melee impact
- update VFX guide for new blend mode and particles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853158455c08327ae9d5b1ee063f586