### PR TITLE
Implement casting speed and VFX effect

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -44,6 +44,7 @@ class Entity {
     get expValue() { return this.stats.get('expValue'); }
     get visionRange() { return this.stats.get('visionRange'); }
     get attackRange() { return this.stats.get('attackRange'); }
+    get castingSpeed() { return this.stats.get('castingSpeed'); }
 
     // --- AI를 동적으로 변경하는 메서드 추가 ---
     updateAI() {

--- a/src/game.js
+++ b/src/game.js
@@ -318,6 +318,7 @@ export class Game {
         eventManager.subscribe('skill_used', (data) => {
             const { caster, skill } = data;
             eventManager.publish('log', { message: `${caster.constructor.name} (이)가 ${skill.name} 스킬 사용!`, color: 'aqua' });
+            this.vfxManager.castEffect(caster, skill);
 
             if (skill.tags.includes('attack')) {
                 const range = skill.range || Infinity;

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -100,6 +100,36 @@ export class VFXManager {
     }
 
     /**
+     * 시전 이펙트: 지정 유닛 주변에서 파티클이 모여드는 애니메이션을 생성합니다.
+     * 시전 속도가 빠를수록 파티클이 더 빠르게 모여듭니다.
+     * 색상은 스킬 태그에 따라 달라집니다.
+     * @param {object} caster Entity casting the skill
+     * @param {object} skill Skill data object
+     */
+    castEffect(caster, skill) {
+        const centerX = caster.x + caster.width / 2;
+        const centerY = caster.y + caster.height / 2;
+        let color = 'white';
+        if (skill && Array.isArray(skill.tags)) {
+            if (skill.tags.includes('fire')) color = 'orange';
+            else if (skill.tags.includes('ice')) color = 'cyan';
+            else if (skill.tags.includes('holy')) color = 'yellow';
+        }
+        const radius = Math.max(caster.width, caster.height);
+        const strength = 0.03 * (caster.stats.get('castingSpeed') || 1);
+        for (let i = 0; i < 4; i++) {
+            const angle = (i / 4) * Math.PI * 2;
+            const sx = centerX + Math.cos(angle) * radius;
+            const sy = centerY + Math.sin(angle) * radius;
+            this.addHomingBurst(sx, sy, caster, {
+                count: 6,
+                color,
+                particleOptions: { homingStrength: strength, gravity: 0 }
+            });
+        }
+    }
+
+    /**
      * 지정한 이미터를 제거합니다.
      * @param {object} emitter
      */

--- a/src/stats.js
+++ b/src/stats.js
@@ -19,9 +19,10 @@ export class StatManager {
             sizeInTiles_h: config.sizeInTiles_h || 1,
             visionRange: config.visionRange || 192 * 4,
             attackRange: config.attackRange || 192,
+            castingSpeed: config.castingSpeed || 1,
         };
         this._pointsAllocated = {
-            strength: 0, agility: 0, endurance: 0, focus: 0, intelligence: 0, movement: 0,
+            strength: 0, agility: 0, endurance: 0, focus: 0, intelligence: 0, movement: 0, castingSpeed: 0,
         };
 
         // 장비로부터 적용되는 스탯 저장용

--- a/tests/statManager.test.js
+++ b/tests/statManager.test.js
@@ -9,6 +9,7 @@ test('초기 스탯 설정', () => {
     const stats = new StatManager({}, jobConfig);
     assert.strictEqual(stats.get('strength'), 5);
     assert.strictEqual(stats.get('endurance'), 10);
+    assert.strictEqual(stats.get('castingSpeed'), 1);
 });
 
 // 파생 스탯(maxHp, attackPower)이 올바르게 계산되는가?


### PR DESCRIPTION
## Summary
- add new `castingSpeed` stat to `StatManager`
- expose `castingSpeed` from entities
- add `castEffect` method to `VFXManager` for homing particles
- trigger casting particles when a skill is used
- test that casting speed defaults to 1

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531a5041a48327a693c9ad8f59fb4d