### PR TITLE
Add weapon overlay for player sprite

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -101,6 +101,21 @@ export class Player extends Entity {
         this.isFriendly = true;
         this.unitType = 'human'; // 플레이어의 타입은 '인간'
     }
+
+    render(ctx) {
+        // 기본 이미지를 그린다
+        super.render(ctx);
+
+        // 장착한 무기가 있으면 플레이어 위에 표시한다
+        const weapon = this.equipment.weapon;
+        if (weapon && weapon.image) {
+            const drawX = this.x + this.width * 0.3;
+            const drawY = this.y + this.height * 0.3;
+            const drawW = this.width * 0.8;
+            const drawH = this.height * 0.8;
+            ctx.drawImage(weapon.image, drawX, drawY, drawW, drawH);
+        }
+    }
 }
 
 export class Mercenary extends Entity {


### PR DESCRIPTION
## Summary
- draw equipped weapon on top of the player image, similar to mercenaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685385719e6083278753a94b4e124c6a