### PR TITLE
Refactor weapon overlay drawing into manager

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -106,14 +106,17 @@ export class Player extends Entity {
         // 기본 이미지를 그린다
         super.render(ctx);
 
-        // 장착한 무기가 있으면 플레이어 위에 표시한다
-        const weapon = this.equipment.weapon;
-        if (weapon && weapon.image) {
-            const drawX = this.x + this.width * 0.3;
-            const drawY = this.y + this.height * 0.3;
-            const drawW = this.width * 0.8;
-            const drawH = this.height * 0.8;
-            ctx.drawImage(weapon.image, drawX, drawY, drawW, drawH);
+        if (this.equipmentRenderManager) {
+            this.equipmentRenderManager.drawWeapon(ctx, this);
+        } else {
+            const weapon = this.equipment.weapon;
+            if (weapon && weapon.image) {
+                const drawX = this.x + this.width * 0.3;
+                const drawY = this.y + this.height * 0.3;
+                const drawW = this.width * 0.8;
+                const drawH = this.height * 0.8;
+                ctx.drawImage(weapon.image, drawX, drawY, drawW, drawH);
+            }
         }
     }
 }
@@ -131,14 +134,17 @@ export class Mercenary extends Entity {
         // 1. 기본 이미지를 먼저 그린다
         super.render(ctx);
 
-        // 2. 장착한 무기가 있으면 그 위에 겹쳐서 그린다
-        const weapon = this.equipment.weapon;
-        if (weapon && weapon.image) {
-            const drawX = this.x + this.width * 0.3;
-            const drawY = this.y + this.height * 0.3;
-            const drawW = this.width * 0.8;
-            const drawH = this.height * 0.8;
-            ctx.drawImage(weapon.image, drawX, drawY, drawW, drawH);
+        if (this.equipmentRenderManager) {
+            this.equipmentRenderManager.drawWeapon(ctx, this);
+        } else {
+            const weapon = this.equipment.weapon;
+            if (weapon && weapon.image) {
+                const drawX = this.x + this.width * 0.3;
+                const drawY = this.y + this.height * 0.3;
+                const drawW = this.width * 0.8;
+                const drawH = this.height * 0.8;
+                ctx.drawImage(weapon.image, drawX, drawY, drawW, drawH);
+            }
         }
     }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -79,6 +79,8 @@ export class Game {
         this.effectManager = this.managers.EffectManager;
         this.projectileManager = this.managers.ProjectileManager;
         this.projectileManager.vfxManager = this.vfxManager;
+        this.equipmentRenderManager = this.managers.EquipmentRenderManager;
+        this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
 
         this.itemFactory = new ItemFactory(assets);
         this.pathfindingManager = new PathfindingManager(this.mapManager);
@@ -110,6 +112,7 @@ export class Game {
             image: assets.player,
             baseStats: { strength: 5, agility: 5, endurance: 15, movement: 10 }
         });
+        player.equipmentRenderManager = this.equipmentRenderManager;
         this.gameState = {
             player,
             inventory: [],

--- a/src/managers/equipmentRenderManager.js
+++ b/src/managers/equipmentRenderManager.js
@@ -1,0 +1,21 @@
+export class EquipmentRenderManager {
+    constructor(eventManager = null, assets = null, factory = null) {
+        console.log('[EquipmentRenderManager] Initialized');
+    }
+
+    getWeaponDrawParams(entity) {
+        return {
+            x: entity.x + entity.width * 0.3,
+            y: entity.y + entity.height * 0.3,
+            width: entity.width * 0.8,
+            height: entity.height * 0.8,
+        };
+    }
+
+    drawWeapon(ctx, entity) {
+        const weapon = entity.equipment?.weapon;
+        if (!weapon || !weapon.image) return;
+        const { x, y, width, height } = this.getWeaponDrawParams(entity);
+        ctx.drawImage(weapon.image, x, y, width, height);
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -12,6 +12,7 @@ import { SoundManager } from './soundManager.js';
 import { EffectManager } from './effectManager.js';
 import { ProjectileManager } from './projectileManager.js';
 import { MotionManager } from './motionManager.js';
+import { EquipmentRenderManager } from './equipmentRenderManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
 
 export {
@@ -26,4 +27,5 @@ export {
     EffectManager,
     ProjectileManager,
     MotionManager,
+    EquipmentRenderManager,
 };

--- a/src/managers/mercenaryManager.js
+++ b/src/managers/mercenaryManager.js
@@ -4,6 +4,7 @@ export class MercenaryManager {
         this.assets = assets;
         this.factory = factory;
         this.mercenaries = [];
+        this.equipmentRenderManager = null;
         console.log("[MercenaryManager] Initialized");
     }
 
@@ -19,7 +20,12 @@ export class MercenaryManager {
             jobId,
             image: this.assets.mercenary,
         });
-        if (merc) this.mercenaries.push(merc);
+        if (merc) {
+            if (this.equipmentRenderManager) {
+                merc.equipmentRenderManager = this.equipmentRenderManager;
+            }
+            this.mercenaries.push(merc);
+        }
         return merc;
     }
 


### PR DESCRIPTION
## Summary
- centralize weapon rendering logic in new `EquipmentRenderManager`
- expose new manager via managers index
- give mercenary manager ability to pass render manager to hired mercs
- hook equipment render manager into game setup and entities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685388eb7c0c8327ab4b6519e8e64ce7