### PR TITLE
Implement skill & tag manager features

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -25,12 +25,10 @@ export class CombatCalculator {
             }
             finalDamage += details.fromSkill;
 
-            // 3. 태그에 의한 추가 데미지 (미래를 위한 구멍)
-            const weapon = attacker.equipment.weapon;
-            if (this.tagManager.hasTag(weapon, 'fire_stone') && this.tagManager.hasTag(skill, 'fire')) {
-                details.fromTags = 5; // 화염석 보너스 +5
-                finalDamage += details.fromTags;
-            }
+            // 3. 태그 조합에 따른 추가 데미지
+            const bonus = this.tagManager.calculateDamageBonus(attacker, skill);
+            details.fromTags = bonus;
+            finalDamage += bonus;
         }
 
         // 4. 방어력에 의한 피해 감소

--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -7,6 +7,34 @@ export const EFFECTS = {
         stats: { strength: 5 },
         tags: ['buff', 'stat_up'],
     },
+    defense_buff: {
+        name: '수비 태세',
+        type: 'buff',
+        duration: 300,
+        stats: { defense: 5 },
+        tags: ['buff', 'defense_up'],
+    },
+    magic_buff: {
+        name: '비전 집중',
+        type: 'buff',
+        duration: 300,
+        stats: { intelligence: 5 },
+        tags: ['buff', 'magic_up'],
+    },
+    magic_resist_buff: {
+        name: '마법 보호막',
+        type: 'buff',
+        duration: 300,
+        stats: { magicResist: 5 },
+        tags: ['buff', 'magic_resist_up'],
+    },
+    all_stat_buff: {
+        name: '신의 가호',
+        type: 'buff',
+        duration: 300,
+        stats: { strength: 2, agility: 2, endurance: 2, intelligence: 2 },
+        tags: ['buff', 'stat_up'],
+    },
     // 디버프
     armor_break: {
         name: '방어구 부수기',
@@ -14,6 +42,34 @@ export const EFFECTS = {
         duration: 300,
         stats: { defense: -10 },
         tags: ['debuff', 'stat_down'],
+    },
+    attack_down: {
+        name: '공격 약화',
+        type: 'debuff',
+        duration: 300,
+        stats: { attackPower: -5 },
+        tags: ['debuff', 'attack_down'],
+    },
+    magic_down: {
+        name: '마법 약화',
+        type: 'debuff',
+        duration: 300,
+        stats: { intelligence: -5 },
+        tags: ['debuff', 'magic_down'],
+    },
+    magic_resist_down: {
+        name: '저항 약화',
+        type: 'debuff',
+        duration: 300,
+        stats: { magicResist: -5 },
+        tags: ['debuff', 'magic_resist_down'],
+    },
+    resist_down: {
+        name: '모든 저항 약화',
+        type: 'debuff',
+        duration: 300,
+        stats: { elementalResist: -5 },
+        tags: ['debuff', 'resist_down'],
     },
     // 상태이상
     poison: {

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -160,6 +160,7 @@ export const SKILLS = {
         manaCost: 14,
         cooldown: 180,
         tags: ['skill', 'buff', 'attack_up', 'self', '버프'],
+        effects: { self: ['strength_buff'] },
     },
     fortress: {
         id: 'fortress',
@@ -168,6 +169,7 @@ export const SKILLS = {
         manaCost: 14,
         cooldown: 180,
         tags: ['skill', 'buff', 'defense_up', 'self', '버프'],
+        effects: { self: ['defense_buff'] },
     },
     arcane_burst: {
         id: 'arcane_burst',
@@ -176,6 +178,7 @@ export const SKILLS = {
         manaCost: 14,
         cooldown: 180,
         tags: ['skill', 'buff', 'magic_up', 'self', '버프'],
+        effects: { self: ['magic_buff'] },
     },
     barrier: {
         id: 'barrier',
@@ -184,6 +187,7 @@ export const SKILLS = {
         manaCost: 14,
         cooldown: 180,
         tags: ['skill', 'buff', 'magic_resist_up', 'self', '버프'],
+        effects: { self: ['magic_resist_buff'] },
     },
     divinity: {
         id: 'divinity',
@@ -192,6 +196,7 @@ export const SKILLS = {
         manaCost: 20,
         cooldown: 240,
         tags: ['skill', 'buff', 'stat_up', 'self', '버프'],
+        effects: { self: ['all_stat_buff'] },
     },
     weaken: {
         id: 'weaken',
@@ -200,6 +205,7 @@ export const SKILLS = {
         manaCost: 12,
         cooldown: 120,
         tags: ['skill', 'debuff', 'attack_down', 'enemy', '디버프'],
+        effects: { target: ['attack_down'] },
     },
     sunder: {
         id: 'sunder',
@@ -208,6 +214,7 @@ export const SKILLS = {
         manaCost: 12,
         cooldown: 120,
         tags: ['skill', 'debuff', 'defense_down', 'enemy', '디버프'],
+        effects: { target: ['armor_break'] },
     },
     regression: {
         id: 'regression',
@@ -216,6 +223,7 @@ export const SKILLS = {
         manaCost: 12,
         cooldown: 120,
         tags: ['skill', 'debuff', 'magic_down', 'enemy', '디버프'],
+        effects: { target: ['magic_down'] },
     },
     spell_weakness: {
         id: 'spell_weakness',
@@ -224,6 +232,7 @@ export const SKILLS = {
         manaCost: 12,
         cooldown: 120,
         tags: ['skill', 'debuff', 'magic_resist_down', 'enemy', '디버프'],
+        effects: { target: ['magic_resist_down'] },
     },
     elemental_weakness: {
         id: 'elemental_weakness',
@@ -232,5 +241,6 @@ export const SKILLS = {
         manaCost: 12,
         cooldown: 120,
         tags: ['skill', 'debuff', 'resist_down', 'enemy', '디버프'],
+        effects: { target: ['resist_down'] },
     },
 };

--- a/src/game.js
+++ b/src/game.js
@@ -82,6 +82,10 @@ export class Game {
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
 
+        // 매니저 간 의존성 연결
+        this.skillManager.setEffectManager(this.effectManager);
+        this.equipmentManager.setTagManager(this.tagManager);
+
         this.itemFactory = new ItemFactory(assets);
         this.pathfindingManager = new PathfindingManager(this.mapManager);
         this.motionManager = new Managers.MotionManager(this.mapManager, this.pathfindingManager);

--- a/src/managers/equipmentManager.js
+++ b/src/managers/equipmentManager.js
@@ -1,7 +1,12 @@
 export class EquipmentManager {
     constructor(eventManager = null) {
         this.eventManager = eventManager;
+        this.tagManager = null;
         console.log('[EquipmentManager] Initialized');
+    }
+
+    setTagManager(tagManager) {
+        this.tagManager = tagManager;
     }
 
     equip(entity, item, inventory) {
@@ -20,6 +25,9 @@ export class EquipmentManager {
         }
         if (typeof entity.updateAI === 'function') {
             entity.updateAI();
+        }
+        if (this.tagManager && typeof this.tagManager.applyWeaponTags === 'function') {
+            this.tagManager.applyWeaponTags(entity);
         }
 
         if (this.eventManager) {

--- a/src/managers/skillManager.js
+++ b/src/managers/skillManager.js
@@ -1,6 +1,31 @@
 export class SkillManager {
-    constructor() {
+    constructor(eventManager = null) {
+        this.eventManager = eventManager;
+        this.effectManager = null;
         console.log("[SkillManager] Initialized");
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('skill_used', ({ caster, skill, target }) => {
+                this.applySkillEffects(caster, skill, target);
+            });
+        }
     }
-    // 나중에 스킬 사용, 효과 처리, 쿨다운 계산 로직 추가
+
+    setEffectManager(effectManager) {
+        this.effectManager = effectManager;
+    }
+
+    applySkillEffects(caster, skill, target = null) {
+        if (!skill || !skill.effects || !this.effectManager) return;
+        if (skill.effects.self) {
+            for (const eff of skill.effects.self) {
+                this.effectManager.addEffect(caster, eff);
+            }
+        }
+        if (skill.effects.target && target) {
+            for (const eff of skill.effects.target) {
+                this.effectManager.addEffect(target, eff);
+            }
+        }
+    }
 }

--- a/src/managers/tagManager.js
+++ b/src/managers/tagManager.js
@@ -1,3 +1,5 @@
+import { RangedAI, MeleeAI } from '../ai.js';
+
 export class TagManager {
     constructor() {
         console.log("[TagManager] Initialized");
@@ -11,5 +13,47 @@ export class TagManager {
      */
     hasTag(target, tag) {
         return target && Array.isArray(target.tags) && target.tags.includes(tag);
+    }
+
+    /**
+     * 장비 태그에 따라 유닛의 AI를 업데이트합니다.
+     * 무기에 'ranged' 태그가 있으면 원거리 AI를,
+     * 'melee' 태그가 있으면 근접 AI를 부여합니다.
+     * @param {object} entity 대상 유닛
+     */
+    applyWeaponTags(entity) {
+        const weapon = entity?.equipment?.weapon;
+        if (!weapon) return;
+
+        if (this.hasTag(weapon, 'ranged')) {
+            if (!(entity.ai instanceof RangedAI)) {
+                entity.ai = new RangedAI();
+            }
+        } else if (this.hasTag(weapon, 'melee')) {
+            if (!(entity.ai instanceof MeleeAI)) {
+                entity.ai = new MeleeAI();
+            }
+        }
+    }
+
+    /**
+     * 장비와 스킬의 태그 조합에 따른 추가 피해를 계산합니다.
+     * 예) 무기에 'fire_rune' 태그가 있고 스킬에 'fire' 태그가 있으면 보너스 데미지
+     * @param {object} attacker 공격자
+     * @param {object} skill 사용 스킬
+     * @returns {number} 추가 피해량
+     */
+    calculateDamageBonus(attacker, skill) {
+        let bonus = 0;
+        const weapon = attacker?.equipment?.weapon;
+        if (!weapon || !skill) return bonus;
+
+        const elements = ['fire', 'ice'];
+        for (const el of elements) {
+            if (this.hasTag(weapon, `${el}_rune`) && this.hasTag(skill, el)) {
+                bonus += 5;
+            }
+        }
+        return bonus;
     }
 }


### PR DESCRIPTION
## Summary
- handle skill effects in SkillManager
- update entity AI and damage bonuses via TagManager
- connect managers in `Game`
- support new buff/debuff effects
- map certain skills to effects
- integrate tag-based damage into CombatCalculator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68539028d2608327b204192ec5341d4a