### PR TITLE
Add test grouping with describe()

### DIFF
--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -1,7 +1,7 @@
 import { MeleeAI, RangedAI } from '../src/ai.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running AI Tests ---");
+describe('AI', () => {
 
 const mapStub = { tileSize: 1, isWallAt: () => false };
 
@@ -56,4 +56,6 @@ test('RangedAI - 사정거리 밖 적에게 접근', () => {
     const action = ai.decideAction(self, context);
     assert.strictEqual(action.type, 'move');
     assert.strictEqual(action.target, enemy);
+});
+
 });

--- a/tests/aiGroupStrategy.test.js
+++ b/tests/aiGroupStrategy.test.js
@@ -1,9 +1,9 @@
 import { MetaAIManager, STRATEGY } from '../src/managers/ai-managers.js';
 import { MeleeAI } from '../src/ai.js';
 import { EventManager } from '../src/managers/eventManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running AI Group Strategy Tests ---");
+describe('AI', () => {
 
 test('setGroupStrategy updates strategy', () => {
     const em = new EventManager();
@@ -29,4 +29,6 @@ test('IDLE strategy prevents movement', () => {
     aiManager.update(context);
     assert.strictEqual(self.x, 0);
     assert.strictEqual(self.y, 0);
+});
+
 });

--- a/tests/aiUpdate.test.js
+++ b/tests/aiUpdate.test.js
@@ -2,9 +2,9 @@ import { Mercenary, Item } from '../src/entities.js';
 import { EquipmentManager } from '../src/managers/equipmentManager.js';
 import { EventManager } from '../src/managers/eventManager.js';
 import { MeleeAI, RangedAI } from '../src/ai.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running AI Update Tests ---");
+describe('AI', () => {
 
 test('AI switches based on equipped weapon tags', () => {
     const em = new EventManager();
@@ -21,4 +21,6 @@ test('AI switches based on equipped weapon tags', () => {
 
     eqManager.equip(merc, sword, []);
     assert.ok(merc.ai instanceof MeleeAI);
+});
+
 });

--- a/tests/attackSpeed.test.js
+++ b/tests/attackSpeed.test.js
@@ -1,9 +1,9 @@
 import { MetaAIManager } from '../src/managers/ai-managers.js';
 import { MeleeAI } from '../src/ai.js';
 import { EventManager } from '../src/managers/eventManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running Attack Speed Tests ---");
+describe('AI', () => {
 
 test('공격 속도가 빠른 유닛이 먼저 공격', () => {
     const em = new EventManager();
@@ -38,4 +38,6 @@ test('공격 속도가 빠른 유닛이 먼저 공격', () => {
     aiManager.update(context);
 
     assert.strictEqual(order[0], 'fast');
+});
+
 });

--- a/tests/combatCalculator.test.js
+++ b/tests/combatCalculator.test.js
@@ -1,9 +1,9 @@
 import { CombatCalculator } from '../src/combat.js';
 import { EventManager } from '../src/managers/eventManager.js';
 import { TagManager } from '../src/managers/tagManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running CombatCalculator Tests ---");
+describe('Combat', () => {
 
 test('피해량 계산 이벤트', () => {
     const eventManager = new EventManager();
@@ -31,4 +31,6 @@ test('피해량 계산 이벤트', () => {
     assert.strictEqual(eventData.attacker, attacker);
     assert.strictEqual(eventData.defender, defender);
     assert.ok(eventData.details);
+});
+
 });

--- a/tests/effectManager.test.js
+++ b/tests/effectManager.test.js
@@ -1,8 +1,8 @@
 import { EffectManager } from '../src/managers/effectManager.js';
 import { EventManager } from '../src/managers/eventManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running EffectManager Tests ---");
+describe('Managers', () => {
 
 test('버프 추가', () => {
     const eventManager = new EventManager();
@@ -16,4 +16,6 @@ test('버프 추가', () => {
     assert.strictEqual(mockTarget.effects.length, 1);
     assert.strictEqual(mockTarget.effects[0].name, '힘의 축복');
     assert.ok(eventFired, 'stats_changed 이벤트');
+});
+
 });

--- a/tests/embargo.test.js
+++ b/tests/embargo.test.js
@@ -7,9 +7,9 @@ import { ItemManager, EquipmentManager } from '../src/managers/managers.js';
 import { TagManager } from '../src/managers/tagManager.js';
 import { CombatCalculator } from '../src/combat.js';
 import { MeleeAI } from '../src/ai.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running Embargo Test ---");
+describe('Integration', () => {
 
 class AutoPlayerAI extends MeleeAI {
     decideAction(self, context) {
@@ -123,5 +123,7 @@ test('맵 순회 자동 플레이', () => {
     });
 
     assert.strictEqual(player.isPlayer, true);
+});
+
 });
 

--- a/tests/eventManager.integration.test.js
+++ b/tests/eventManager.integration.test.js
@@ -1,7 +1,7 @@
 import { EventManager } from '../src/managers/eventManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running EventManager Integration Tests ---");
+describe('Integration', () => {
 
 test('이벤트 매니저 통합 동작', () => {
     // 1. 테스트 환경 설정
@@ -39,4 +39,6 @@ test('이벤트 매니저 통합 동작', () => {
     assert.ok(combatLogReceived, "CombatLogManager가 'log' 이벤트를 수신하지 못했습니다.");
     assert.ok(systemLogReceived, "SystemLogManager가 'debug' 이벤트를 수신하지 못했습니다.");
     assert.ok(statsChangeReceived, '스탯 변경 이벤트가 정상적으로 수신되지 않았습니다.');
+});
+
 });

--- a/tests/eventManager.test.js
+++ b/tests/eventManager.test.js
@@ -1,7 +1,7 @@
 import { EventManager } from '../src/managers/eventManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running EventManager Tests ---");
+describe('Managers', () => {
 
 test('publish가 구독자 호출', () => {
     const em = new EventManager();
@@ -9,4 +9,6 @@ test('publish가 구독자 호출', () => {
     em.subscribe('test', () => { called = true; });
     em.publish('test', {});
     assert.ok(called);
+});
+
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,11 +1,28 @@
 import assert from 'assert';
 
+const describeStack = [];
+const groupFilter = process.env.GROUP;
+
+export function describe(name, fn) {
+    describeStack.push(name);
+    const indent = ' '.repeat(describeStack.length - 1);
+    const shouldRun = !groupFilter || describeStack.includes(groupFilter);
+    if (shouldRun) {
+        console.log(`${indent}📂 ${name}`);
+    }
+    fn();
+    describeStack.pop();
+}
+
 export function test(name, fn) {
+    const shouldRun = !groupFilter || describeStack.includes(groupFilter);
+    if (!shouldRun) return;
+    const indent = ' '.repeat(describeStack.length);
     try {
         fn();
-        console.log(`✅ PASSED: ${name}`);
+        console.log(`${indent}✅ PASSED: ${name}`);
     } catch (e) {
-        console.error(`❌ FAILED: ${name} - ${e.message}`);
+        console.error(`${indent}❌ FAILED: ${name} - ${e.message}`);
     }
 }
 

--- a/tests/mapManager.test.js
+++ b/tests/mapManager.test.js
@@ -1,59 +1,48 @@
 import { MapManager } from '../src/map.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running MapManager Tests ---");
-
-try {
+describe('Managers', () => {
+  test('맵 연결성 테스트', () => {
     const mapManager = new MapManager(12345);
-    const map = mapManager.map;
-    const { width, height } = mapManager;
-    const TILE_TYPES = mapManager.tileTypes;
+    const { width, height, tileTypes, map } = mapManager;
 
-    // 테스트 1: 모든 복도와 방이 하나로 연결되어 있는가? (Flood Fill 알고리즘 사용)
     let startNode = null;
     let floorCount = 0;
     for (let y = 0; y < height; y++) {
-        for (let x = 0; x < width; x++) {
-            if (map[y][x] === TILE_TYPES.FLOOR) {
-                if (!startNode) startNode = { x, y };
-                floorCount++;
-            }
+      for (let x = 0; x < width; x++) {
+        if (map[y][x] === tileTypes.FLOOR) {
+          if (!startNode) startNode = { x, y };
+          floorCount++;
         }
+      }
     }
 
-    if (startNode) {
-        const visited = new Set();
-        const queue = [startNode];
-        visited.add(`${startNode.x},${startNode.y}`);
-        let connectedCount = 0;
+    assert.ok(startNode, '맵에 시작 지점을 찾을 수 없습니다.');
 
-        while (queue.length > 0) {
-            const current = queue.shift();
-            connectedCount++;
-            const { x, y } = current;
-            const neighbors = [
-                { x: x + 1, y: y },
-                { x: x - 1, y: y },
-                { x: x, y: y + 1 },
-                { x: x, y: y - 1 }
-            ];
+    const visited = new Set();
+    const queue = [startNode];
+    visited.add(`${startNode.x},${startNode.y}`);
+    let connectedCount = 0;
 
-            for (const n of neighbors) {
-                const key = `${n.x},${n.y}`;
-                if (map[n.y] && map[n.y][n.x] === TILE_TYPES.FLOOR && !visited.has(key)) {
-                    visited.add(key);
-                    queue.push(n);
-                }
-            }
+    while (queue.length > 0) {
+      const current = queue.shift();
+      connectedCount++;
+      const { x, y } = current;
+      const neighbors = [
+        { x: x + 1, y },
+        { x: x - 1, y },
+        { x, y: y + 1 },
+        { x, y: y - 1 },
+      ];
+      for (const n of neighbors) {
+        const key = `${n.x},${n.y}`;
+        if (map[n.y] && map[n.y][n.x] === tileTypes.FLOOR && !visited.has(key)) {
+          visited.add(key);
+          queue.push(n);
         }
-
-        if (connectedCount !== floorCount) {
-            throw new Error(`맵이 고립된 공간을 포함합니다. 전체 바닥: ${floorCount}, 연결된 바닥: ${connectedCount}`);
-        }
-        console.log("✅ PASSED: 맵 연결성 테스트");
-    } else {
-        throw new Error("맵에 시작 지점을 찾을 수 없습니다.");
+      }
     }
 
-} catch (e) {
-    console.error(`❌ FAILED: 맵 유효성 검사 - ${e.message}`);
-}
+    assert.strictEqual(connectedCount, floorCount, '맵이 고립된 공간을 포함합니다.');
+  });
+});

--- a/tests/mercenarySkills.test.js
+++ b/tests/mercenarySkills.test.js
@@ -1,8 +1,8 @@
 import { CharacterFactory } from '../src/factory.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 import { SKILLS } from '../src/data/skills.js';
 
-console.log("--- Running Mercenary Skill Tests ---");
+describe('Managers', () => {
 
 const assets = { mercenary:{} };
 
@@ -33,4 +33,6 @@ test('궁수 스킬 부여 - double_thrust', () => {
 test('궁수 스킬 부여 - hawk_eye', () => {
     const merc = createMercWithRandom(0.9, 'archer');
     assert.strictEqual(merc.skills[0], SKILLS.hawk_eye.id);
+});
+
 });

--- a/tests/microSmoke.test.js
+++ b/tests/microSmoke.test.js
@@ -3,9 +3,9 @@ import { CharacterFactory, ItemFactory } from '../src/factory.js';
 import { MercenaryManager } from '../src/managers/managers.js';
 import { EventManager } from '../src/managers/eventManager.js';
 import { monsterDeathWorkflow } from '../src/workflows.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running Micro Smoke Test ---");
+describe('Integration', () => {
 
 test('간단한 게임 흐름', () => {
     const assets = { player:{}, mercenary:{}, monster:{}, sword:{}, leather_armor:{} };
@@ -41,4 +41,6 @@ test('간단한 게임 흐름', () => {
     merc.stats.updateEquipmentStats();
     merc.updateAI();
     assert.ok(merc.stats.get('attackPower') > beforeAtk, '장비 장착 후 스탯 증가');
+});
+
 });

--- a/tests/motionManager.test.js
+++ b/tests/motionManager.test.js
@@ -1,8 +1,8 @@
 import { PathfindingManager } from '../src/managers/pathfindingManager.js';
 import { MotionManager } from '../src/managers/motionManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running MotionManager Tests ---");
+describe('Managers', () => {
 
 test('dashTowards 이동 거리 제한', () => {
     const mapManager = {
@@ -20,4 +20,6 @@ test('dashTowards 이동 거리 제한', () => {
     motion.dashTowards(entity, target, 3);
     assert.strictEqual(entity.x, 3);
     assert.strictEqual(entity.y, 0);
+});
+
 });

--- a/tests/movementManager.test.js
+++ b/tests/movementManager.test.js
@@ -1,36 +1,19 @@
 import { MovementManager } from '../src/managers/movementManager.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running MovementManager Tests ---");
-
-try {
-    // 가짜 맵 매니저 생성
+describe('Managers', () => {
+  test('끼임 방지 로직 호출 (상세 테스트 필요)', () => {
     const mockMapManager = {
-        tileSize: 10,
-        isWallAt: (x, y) => {
-            // (50, 50)에 가상의 벽이 있다고 가정
-            return x >= 50 && x < 60 && y >= 50 && y < 60;
-        }
+      tileSize: 10,
+      isWallAt: (x, y) => x >= 50 && x < 60 && y >= 50 && y < 60,
     };
     const movementManager = new MovementManager(mockMapManager);
-    
-    // 테스트 유닛과 목표
     const entity = { id: 'test', x: 45, y: 52, width: 10, height: 10, speed: 5 };
     const target = { x: 100, y: 52 };
 
-    // 벽을 향해 이동 시도
     movementManager.moveEntityTowards(entity, target);
-    
-    // X축 이동은 막혔지만, Y축으로는 미끄러져야 함 (실제 구현은 더 복잡하지만 개념 테스트)
-    // 현재 구현은 X축, Y축을 분리 시도하므로, X가 막히면 Y로 움직이려 함
-    // 이 테스트는 현재 _isOccupied가 다른 유닛을 체크 안하므로, 
-    // X, Y 동시 이동 시도 -> 막힘 -> X축만 이동 시도 -> 막힘 -> Y축만 이동 시도 -> 안막힘 -> Y만 바뀜
-    // 이 복잡한 로직을 테스트하려면 더 정교한 Mock이 필요. 지금은 생성과 호출만 테스트.
-    if (entity.x === 45 && entity.y === 52) {
-         console.log("✅ PASSED: 끼임 방지 로직 호출 (상세 테스트 필요)");
-    } else {
-        throw new Error("끼임 방지 로직이 작동하지 않음");
-    }
 
-} catch (e) {
-    console.error(`❌ FAILED: MovementManager 테스트 - ${e.message}`);
-}
+    assert.strictEqual(entity.x, 45);
+    assert.strictEqual(entity.y, 52);
+  });
+});

--- a/tests/pathfindingManager.test.js
+++ b/tests/pathfindingManager.test.js
@@ -1,7 +1,7 @@
 import { PathfindingManager } from '../src/managers/pathfindingManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running PathfindingManager Tests ---");
+describe('Managers', () => {
 
 test('생성', () => {
     const pfManager = new PathfindingManager(null);
@@ -75,4 +75,6 @@ test('탈출 경로 탐색', () => {
     const pfManager = new PathfindingManager(mapManager);
     const escape = pfManager.findEscapeRoute(1,1, () => false);
     assert.deepStrictEqual(escape, {x:2,y:1});
+});
+
 });

--- a/tests/random.test.js
+++ b/tests/random.test.js
@@ -1,7 +1,7 @@
 import { rollOnTable, rollDiceNotation } from '../src/utils/random.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running Random (DiceBot) Tests ---");
+describe('Utility', () => {
 
 test('가중치 기반 롤링', () => {
     const testTable = [
@@ -19,4 +19,6 @@ test('주사위 표기법 굴리기', () => {
     Math.random = originalRandom;
     // 2d6 with roll 1 each -> 2 + 3 = 5
     assert.strictEqual(result, 5);
+});
+
 });

--- a/tests/statManager.test.js
+++ b/tests/statManager.test.js
@@ -1,7 +1,7 @@
 import { StatManager } from '../src/stats.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running StatManager Tests ---");
+describe('StatManager', () => {
 
 // 초기 스탯이 올바르게 설정되는가?
 test('초기 스탯 설정', () => {
@@ -42,4 +42,4 @@ test('레벨 업', () => {
     assert.strictEqual(stats.get('endurance'), 2);
 });
 
-console.log("--- StatManager Tests Finished ---");
+});

--- a/tests/turnManager.test.js
+++ b/tests/turnManager.test.js
@@ -1,7 +1,7 @@
 import { TurnManager } from '../src/managers/turnManager.js';
-import { test, assert } from './helpers.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running TurnManager Tests ---");
+describe('Managers', () => {
 
 test('턴 카운트 증가', () => {
     const turnManager = new TurnManager();
@@ -10,4 +10,6 @@ test('턴 카운트 증가', () => {
         turnManager.update([]);
     }
     assert.strictEqual(turnManager.turnCount, 1);
+});
+
 });

--- a/tests/workflows.test.js
+++ b/tests/workflows.test.js
@@ -1,61 +1,48 @@
 import { monsterDeathWorkflow } from '../src/workflows.js';
 import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
 
-console.log("--- Running Workflow Tests ---");
-
-try {
-    // 1. 테스트 환경 설정
+describe('Integration', () => {
+  test('몬스터 사망 워크플로우', () => {
     const eventManager = new EventManager();
-    
-    // 테스트 결과를 기록할 변수들
+
     let deathEventFired = false;
     let expEventFired = false;
     let lootEventFired = false;
     let removedEventFired = false;
     let gainedExp = 0;
 
-    // 2. 가짜(mock) 데이터 생성
-    const mockAttacker = { 
-        isPlayer: true, 
-        isFriendly: true,
-        stats: { 
-            addExp: (exp) => { gainedExp = exp; }
-        } 
+    const mockAttacker = {
+      isPlayer: true,
+      isFriendly: true,
+      stats: {
+        addExp: (exp) => {
+          gainedExp = exp;
+        },
+      },
     };
-    const mockVictim = { 
-        id: 'monster-123',
-        expValue: 50,
-        x: 100, y: 100,
-        constructor: { name: 'Monster' }
+    const mockVictim = {
+      id: 'monster-123',
+      expValue: 50,
+      x: 100,
+      y: 100,
+      constructor: { name: 'Monster' },
     };
-    const context = {
-        eventManager,
-        attacker: mockAttacker,
-        victim: mockVictim,
-    };
+    const context = { eventManager, attacker: mockAttacker, victim: mockVictim };
 
-    // 3. 워크플로우 실행 전에 이벤트 구독
-    eventManager.subscribe('entity_death', () => { deathEventFired = true; });
-    eventManager.subscribe('exp_gained', (data) => { expEventFired = true; });
-    eventManager.subscribe('drop_loot', () => { lootEventFired = true; });
+    eventManager.subscribe('entity_death', () => { deathEventFired = true });
+    eventManager.subscribe('exp_gained', () => { expEventFired = true });
+    eventManager.subscribe('drop_loot', () => { lootEventFired = true });
     eventManager.subscribe('entity_removed', (data) => {
-        if(data.victimId === 'monster-123') {
-            removedEventFired = true;
-        }
+      if (data.victimId === 'monster-123') removedEventFired = true;
     });
-    
-    // 4. 워크플로우 실행!
+
     monsterDeathWorkflow(context);
 
-    // 5. 결과 확인
-    if (!deathEventFired) throw new Error("사망(entity_death) 이벤트가 발생하지 않음");
-    if (!expEventFired) throw new Error("경험치 획득(exp_gained) 이벤트가 발생하지 않음");
-    if (!lootEventFired) throw new Error("아이템 드랍(drop_loot) 이벤트가 발생하지 않음");
-    if (!removedEventFired) throw new Error("개체 제거(entity_removed) 이벤트가 발생하지 않음");
-    if (gainedExp !== 50) throw new Error(`획득 경험치가 50이 아님 (실제: ${gainedExp})`);
-
-    console.log("✅ PASSED: 몬스터 사망 워크플로우");
-
-} catch (e) {
-    console.error(`❌ FAILED: 몬스터 사망 워크플로우 - ${e.message}`);
-}
+    assert.ok(deathEventFired, '사망(entity_death) 이벤트가 발생하지 않음');
+    assert.ok(expEventFired, '경험치 획득(exp_gained) 이벤트가 발생하지 않음');
+    assert.ok(lootEventFired, '아이템 드랍(drop_loot) 이벤트가 발생하지 않음');
+    assert.ok(removedEventFired, '개체 제거(entity_removed) 이벤트가 발생하지 않음');
+    assert.strictEqual(gainedExp, 50, '획득 경험치가 50이 아님');
+  });
+});


### PR DESCRIPTION
## Summary
- add `describe` helper supporting group filtering
- reorganize tests into groups using `describe`
- rewrite non-standard tests to use `test` helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68539519058c8327a7556e79a7a9e945