### PR TITLE
Implement charge attack skill

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -40,6 +40,20 @@ export class MeleeAI extends AIArchetype {
                 Math.floor(nearestTarget.y / mapManager.tileSize),
                 mapManager
             );
+            const chargeSkill = Array.isArray(self.skills)
+                ? self.skills.map(id => SKILLS[id]).find(s => s && s.tags && s.tags.includes('charge'))
+                : null;
+
+            if (
+                chargeSkill &&
+                minDistance > self.attackRange &&
+                minDistance <= chargeSkill.chargeRange &&
+                self.mp >= chargeSkill.manaCost &&
+                (self.skillCooldowns[chargeSkill.id] || 0) <= 0
+            ) {
+                return { type: 'charge_attack', target: nearestTarget, skill: chargeSkill };
+            }
+
             if (hasLOS && minDistance < self.attackRange) {
                 // 사용할 수 있는 스킬이 있다면 스킬 사용
                 const skillId = self.skills && self.skills[0];

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -30,12 +30,12 @@ export const SKILLS = {
     charge_attack: {
         id: 'charge_attack',
         name: '돌진 공격',
-        description: '대시하여 적을 강하게 공격합니다.',
-        manaCost: 8,
-        cooldown: 180,
+        description: '적에게 빠르게 돌진하여 강력한 피해를 입힙니다.',
+        manaCost: 15,
+        cooldown: 300,
         damageMultiplier: 1.5,
-        dashRange: 8,
-        tags: ['skill', 'attack', 'melee', 'physical', 'dash', '근접', '물리'],
+        chargeRange: 192 * 4,
+        tags: ['skill', 'attack', 'melee', 'movement', 'charge'],
     },
     double_strike: {
         id: 'double_strike',

--- a/src/factory.js
+++ b/src/factory.js
@@ -63,6 +63,8 @@ export class CharacterFactory {
                     merc.skills.push(rangedSkill);
                     merc.equipment.weapon = { tags: ['weapon', 'ranged', 'bow'] };
                     merc.ai = new RangedAI();
+                } else if (config.jobId === 'warrior') {
+                    merc.skills.push(SKILLS.charge_attack.id);
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);

--- a/src/game.js
+++ b/src/game.js
@@ -357,6 +357,12 @@ export class Game {
             }
         });
 
+        eventManager.subscribe('vfx_request', (data) => {
+            if (data.type === 'dash_trail') {
+                this.vfxManager.createDashTrail(data.from.x, data.from.y, data.to.x, data.to.y);
+            }
+        });
+
         // 스탯 변경 이벤트 구독 (효과 적용/해제 시 스탯 재계산)
         eventManager.subscribe('stats_changed', (data) => {
             data.entity.stats.recalculate();

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -76,6 +76,24 @@ export class MetaAIManager {
                     entity.attackCooldown = Math.max(1, Math.round(baseCd / (entity.attackSpeed || 1)));
                 }
                 break;
+            case 'charge_attack': {
+                const { eventManager: ev } = context;
+                const { target, skill } = action;
+                ev.publish('vfx_request', {
+                    type: 'dash_trail',
+                    from: { x: entity.x, y: entity.y },
+                    to: { x: target.x, y: target.y }
+                });
+                const dx = target.x - entity.x;
+                const dy = target.y - entity.y;
+                const dist = Math.hypot(dx, dy) || 1;
+                entity.x = target.x - (dx / dist) * entity.width;
+                entity.y = target.y - (dy / dist) * entity.height;
+                ev.publish('entity_attack', { attacker: entity, defender: target, skill });
+                entity.mp -= skill.manaCost;
+                entity.skillCooldowns[skill.id] = skill.cooldown;
+                entity.attackCooldown = Math.max(1, Math.round(60 / (entity.attackSpeed || 1)));
+                break; }
             case 'move':
                 const { movementManager } = context;
                 if (movementManager) {

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -99,6 +99,19 @@ export class VFXManager {
         }
     }
 
+    createDashTrail(fromX, fromY, toX, toY) {
+        const particleCount = 10;
+        for (let i = 0; i < particleCount; i++) {
+            const progress = i / particleCount;
+            const x = fromX + (toX - fromX) * progress;
+            const y = fromY + (toY - fromY) * progress;
+            const particle = new Particle(x, y, 'rgba(255, 255, 255, 0.5)');
+            particle.lifespan = 20;
+            particle.gravity = 0;
+            this.particles.push(particle);
+        }
+    }
+
     /**
      * 시전 이펙트: 지정 유닛 주변에서 파티클이 모여드는 애니메이션을 생성합니다.
      * 시전 속도가 빠를수록 파티클이 더 빠르게 모여듭니다.

--- a/tests/mercenarySkills.test.js
+++ b/tests/mercenarySkills.test.js
@@ -6,7 +6,7 @@ describe('Managers', () => {
 
 const assets = { mercenary:{} };
 
-function createMercWithRandom(randomValue, jobId = 'warrior') {
+function createMerc(jobId = undefined, randomValue = 0.5) {
     const original = Math.random;
     Math.random = () => randomValue;
     const factory = new CharacterFactory(assets);
@@ -15,23 +15,28 @@ function createMercWithRandom(randomValue, jobId = 'warrior') {
     return merc;
 }
 
-test('무작위 스킬 부여 - double_strike', () => {
-    const merc = createMercWithRandom(0.1);
+test('전사 기본 스킬 - charge_attack', () => {
+    const merc = createMerc('warrior');
+    assert.strictEqual(merc.skills[0], SKILLS.charge_attack.id);
+});
+
+test('기본 용병 무작위 스킬 - double_strike', () => {
+    const merc = createMerc(undefined, 0.1);
     assert.strictEqual(merc.skills[0], SKILLS.double_strike.id);
 });
 
-test('무작위 스킬 부여 - charge_attack', () => {
-    const merc = createMercWithRandom(0.9);
+test('기본 용병 무작위 스킬 - charge_attack', () => {
+    const merc = createMerc(undefined, 0.9);
     assert.strictEqual(merc.skills[0], SKILLS.charge_attack.id);
 });
 
 test('궁수 스킬 부여 - double_thrust', () => {
-    const merc = createMercWithRandom(0.1, 'archer');
+    const merc = createMerc('archer', 0.1);
     assert.strictEqual(merc.skills[0], SKILLS.double_thrust.id);
 });
 
 test('궁수 스킬 부여 - hawk_eye', () => {
-    const merc = createMercWithRandom(0.9, 'archer');
+    const merc = createMerc('archer', 0.9);
     assert.strictEqual(merc.skills[0], SKILLS.hawk_eye.id);
 });
 


### PR DESCRIPTION
## Summary
- update `charge_attack` data in `SKILLS`
- give warriors the charge skill in `CharacterFactory`
- let `MeleeAI` attempt a charge attack when in range
- handle new `charge_attack` action inside `MetaAIManager`
- add dash trail effect in `VFXManager` and react to it in `Game`
- update tests for new mercenary skill behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685398ae2420832783cbfb6681fdebfd