### PR TITLE
Implement random MBTI generation

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -9,3 +9,8 @@
 - 힐러 직업과 `HealerAI` 구현.
 - 고유 스킬 `heal`을 사용해 아군을 회복하도록 테스트 추가.
 - `CharacterFactory`가 `jobId: 'healer'`를 처리하도록 수정.
+
+## 세션 3
+- MBTI 데이터 테이블 추가.
+- `CharacterFactory`가 무작위 MBTI를 부여하도록 수정.
+- 해당 기능을 검증하는 테스트 `mbti.test.js` 작성.

--- a/src/data/mbti.js
+++ b/src/data/mbti.js
@@ -1,0 +1,6 @@
+export const MBTI_TYPES = [
+    'ISTJ', 'ISFJ', 'INFJ', 'INTJ',
+    'ISTP', 'ISFP', 'INFP', 'INTP',
+    'ESTP', 'ESFP', 'ENFP', 'ENTP',
+    'ESTJ', 'ESFJ', 'ENFJ', 'ENTJ'
+];

--- a/src/factory.js
+++ b/src/factory.js
@@ -9,6 +9,7 @@ import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
 import { RangedAI, HealerAI } from './ai.js';
+import { MBTI_TYPES } from './data/mbti.js';
 
 export class CharacterFactory {
     constructor(assets) {
@@ -80,7 +81,10 @@ export class CharacterFactory {
     }
     
     // === 아래는 다이스를 굴리는 내부 함수들 (구멍만 파기) ===
-    _rollMBTI() { return 'ISTJ'; }
+    _rollMBTI() {
+        const index = Math.floor(Math.random() * MBTI_TYPES.length);
+        return MBTI_TYPES[index];
+    }
     _rollRandomKey(obj) { const keys = Object.keys(obj); return keys[Math.floor(Math.random() * keys.length)]; }
     _rollStars() {
         // ... (별 갯수 랜덤 배분 로직) ...

--- a/tests/mbti.test.js
+++ b/tests/mbti.test.js
@@ -1,0 +1,13 @@
+import { CharacterFactory } from '../src/factory.js';
+import { MBTI_TYPES } from '../src/data/mbti.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('CharacterFactory', () => {
+
+    test('_rollMBTI returns valid type', () => {
+        const factory = new CharacterFactory({});
+        const mbti = factory._rollMBTI();
+        assert.ok(MBTI_TYPES.includes(mbti));
+    });
+
+});


### PR DESCRIPTION
## Summary
- generate MBTI from a data table
- update CharacterFactory to use randomized MBTI
- add corresponding test
- log work in codex's room

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853a8e97a6c8327a96dd480db67ba17