### PR TITLE
Add FileLogManager and log update

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -9,3 +9,13 @@
 - 힐러 직업과 `HealerAI` 구현.
 - 고유 스킬 `heal`을 사용해 아군을 회복하도록 테스트 추가.
 - `CharacterFactory`가 `jobId: 'healer'`를 처리하도록 수정.
+
+## 세션 3
+- MBTI 데이터 테이블 추가.
+- `CharacterFactory`가 무작위 MBTI를 부여하도록 수정.
+- 해당 기능을 검증하는 테스트 `mbti.test.js` 작성.
+
+## 세션 4
+- 파일 전투 로그 매니저(`FileLogManager`) 구현.
+- 'log' 이벤트를 파일로 기록하도록 추가.
+- `fileLogManager.test.js` 테스트로 동작 확인.

--- a/src/data/mbti.js
+++ b/src/data/mbti.js
@@ -1,0 +1,6 @@
+export const MBTI_TYPES = [
+    'ISTJ', 'ISFJ', 'INFJ', 'INTJ',
+    'ISTP', 'ISFP', 'INFP', 'INTP',
+    'ESTP', 'ESFP', 'ENFP', 'ENTP',
+    'ESTJ', 'ESFJ', 'ENFJ', 'ENTJ'
+];

--- a/src/factory.js
+++ b/src/factory.js
@@ -9,6 +9,7 @@ import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
 import { RangedAI, HealerAI } from './ai.js';
+import { MBTI_TYPES } from './data/mbti.js';
 
 export class CharacterFactory {
     constructor(assets) {
@@ -80,7 +81,10 @@ export class CharacterFactory {
     }
     
     // === 아래는 다이스를 굴리는 내부 함수들 (구멍만 파기) ===
-    _rollMBTI() { return 'ISTJ'; }
+    _rollMBTI() {
+        const index = Math.floor(Math.random() * MBTI_TYPES.length);
+        return MBTI_TYPES[index];
+    }
     _rollRandomKey(obj) { const keys = Object.keys(obj); return keys[Math.floor(Math.random() * keys.length)]; }
     _rollStars() {
         // ... (별 갯수 랜덤 배분 로직) ...

--- a/src/managers/fileLogManager.js
+++ b/src/managers/fileLogManager.js
@@ -1,0 +1,26 @@
+import { appendFileSync, writeFileSync } from 'fs';
+
+export class FileLogManager {
+    constructor(eventManager, filePath = 'combat.log') {
+        this.filePath = filePath;
+        // initialize file
+        try {
+            writeFileSync(this.filePath, '', { flag: 'w' });
+        } catch (e) {
+            console.error('Failed to initialize log file', e);
+        }
+        eventManager.subscribe('log', (data) => {
+            if (data && data.message) {
+                this.write(data.message);
+            }
+        });
+    }
+
+    write(message) {
+        try {
+            appendFileSync(this.filePath, message + '\n');
+        } catch (e) {
+            console.error('Failed to write log', e);
+        }
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -14,6 +14,7 @@ import { ProjectileManager } from './projectileManager.js';
 import { MotionManager } from './motionManager.js';
 import { MovementManager } from './movementManager.js';
 import { EquipmentRenderManager } from './equipmentRenderManager.js';
+import { FileLogManager } from './fileLogManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
 
 export {
@@ -30,4 +31,5 @@ export {
     MotionManager,
     MovementManager,
     EquipmentRenderManager,
+    FileLogManager,
 };

--- a/tests/fileLogManager.test.js
+++ b/tests/fileLogManager.test.js
@@ -1,0 +1,18 @@
+import { EventManager } from '../src/managers/eventManager.js';
+import { FileLogManager } from '../src/managers/fileLogManager.js';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { describe, test, assert } from './helpers.js';
+
+const LOG_PATH = './tests/tmp-combat.log';
+
+describe('FileLogManager', () => {
+    test('writes log messages to file', () => {
+        if (existsSync(LOG_PATH)) unlinkSync(LOG_PATH);
+        const eventManager = new EventManager();
+        new FileLogManager(eventManager, LOG_PATH);
+        eventManager.publish('log', { message: 'File log test' });
+        const content = readFileSync(LOG_PATH, 'utf-8').trim();
+        assert.strictEqual(content, 'File log test');
+        unlinkSync(LOG_PATH);
+    });
+});

--- a/tests/mbti.test.js
+++ b/tests/mbti.test.js
@@ -1,0 +1,13 @@
+import { CharacterFactory } from '../src/factory.js';
+import { MBTI_TYPES } from '../src/data/mbti.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('CharacterFactory', () => {
+
+    test('_rollMBTI returns valid type', () => {
+        const factory = new CharacterFactory({});
+        const mbti = factory._rollMBTI();
+        assert.ok(MBTI_TYPES.includes(mbti));
+    });
+
+});


### PR DESCRIPTION
## Summary
- implement FileLogManager for writing 'log' events to file
- add test verifying file output
- export FileLogManager from managers index
- record work in codex's room dev log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853a8e97a6c8327a96dd480db67ba17