### PR TITLE
Add MBTI randomization and file logging

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -9,6 +9,7 @@ import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
 import { RangedAI, HealerAI } from './ai.js';
+import { MBTI_TYPES } from './data/mbti.js';
 
 export class CharacterFactory {
     constructor(assets) {
@@ -80,7 +81,10 @@ export class CharacterFactory {
     }
     
     // === 아래는 다이스를 굴리는 내부 함수들 (구멍만 파기) ===
-    _rollMBTI() { return 'ISTJ'; }
+    _rollMBTI() {
+        const index = Math.floor(Math.random() * MBTI_TYPES.length);
+        return MBTI_TYPES[index];
+    }
     _rollRandomKey(obj) { const keys = Object.keys(obj); return keys[Math.floor(Math.random() * keys.length)]; }
     _rollStars() {
         // ... (별 갯수 랜덤 배분 로직) ...

--- a/src/managers/fileLogManager.js
+++ b/src/managers/fileLogManager.js
@@ -1,23 +1,26 @@
-import fs from 'fs';
+import { appendFileSync, writeFileSync } from 'fs';
 
 export class FileLogManager {
     constructor(eventManager, filePath = 'combat.log') {
         this.filePath = filePath;
-        if (eventManager) {
-            eventManager.subscribe('log', data => {
-                if (data && data.message) {
-                    this.log(data.message);
-                }
-            });
+        // initialize file
+        try {
+            writeFileSync(this.filePath, '', { flag: 'w' });
+        } catch (e) {
+            console.error('Failed to initialize log file', e);
         }
+        eventManager.subscribe('log', (data) => {
+            if (data && data.message) {
+                this.write(data.message);
+            }
+        });
     }
 
-    log(message) {
-        const timestamp = new Date().toISOString();
-        fs.appendFileSync(this.filePath, `[${timestamp}] ${message}\n`);
-    }
-
-    clear() {
-        fs.writeFileSync(this.filePath, '');
+    write(message) {
+        try {
+            appendFileSync(this.filePath, message + '\n');
+        } catch (e) {
+            console.error('Failed to write log', e);
+        }
     }
 }

--- a/tests/fileLogManager.test.js
+++ b/tests/fileLogManager.test.js
@@ -1,18 +1,18 @@
-import { FileLogManager } from '../src/managers/fileLogManager.js';
 import { EventManager } from '../src/managers/eventManager.js';
-import fs from 'fs';
+import { FileLogManager } from '../src/managers/fileLogManager.js';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
 import { describe, test, assert } from './helpers.js';
 
-const LOG_FILE = 'test-combat.log';
+const LOG_PATH = './tests/tmp-combat.log';
 
 describe('FileLogManager', () => {
     test('writes log messages to file', () => {
-        if (fs.existsSync(LOG_FILE)) fs.unlinkSync(LOG_FILE);
+        if (existsSync(LOG_PATH)) unlinkSync(LOG_PATH);
         const eventManager = new EventManager();
-        const fileLogger = new FileLogManager(eventManager, LOG_FILE);
-        eventManager.publish('log', { message: 'hello world' });
-        const content = fs.readFileSync(LOG_FILE, 'utf8');
-        assert.ok(content.includes('hello world'));
-        fs.unlinkSync(LOG_FILE);
+        new FileLogManager(eventManager, LOG_PATH);
+        eventManager.publish('log', { message: 'File log test' });
+        const content = readFileSync(LOG_PATH, 'utf-8').trim();
+        assert.strictEqual(content, 'File log test');
+        unlinkSync(LOG_PATH);
     });
 });

--- a/tests/mbti.test.js
+++ b/tests/mbti.test.js
@@ -1,0 +1,13 @@
+import { CharacterFactory } from '../src/factory.js';
+import { MBTI_TYPES } from '../src/data/mbti.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('CharacterFactory', () => {
+
+    test('_rollMBTI returns valid type', () => {
+        const factory = new CharacterFactory({});
+        const mbti = factory._rollMBTI();
+        assert.ok(MBTI_TYPES.includes(mbti));
+    });
+
+});


### PR DESCRIPTION
## Summary
- randomize MBTI when creating characters
- implement streamlined FileLogManager
- update FileLogManager test
- add mbti.test.js for MBTI functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853aca2de6083279348aa687982612b