### PR TITLE
Add start==end check in pathfinding

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -28,3 +28,7 @@
 ## 세션 6
 - `HealerAI`가 MBTI 성향에 따라 치유 시점을 다르게 판단하도록 개선.
 - `ai.test.js`에 감각형/직관형 행동 테스트 두 가지를 추가.
+
+## 세션 7
+- `PathfindingManager.findPath`가 시작과 끝이 같을 때 바로 빈 배열을 반환하도록 수정.
+- `pathfindingManager.test.js`에 해당 케이스 테스트 추가.

--- a/src/managers/pathfindingManager.js
+++ b/src/managers/pathfindingManager.js
@@ -56,6 +56,10 @@ export class PathfindingManager {
 
     // 타겟 주변의 이동 가능한 위치까지 경로를 찾는다.
     findPath(startX, startY, endX, endY, isBlocked = () => false) {
+        if (startX === endX && startY === endY) {
+            return [];
+        }
+
         console.log(`Pathfinding from (${startX},${startY}) to (${endX},${endY})`);
 
         const basePath = this._bfs(startX, startY, endX, endY, isBlocked);

--- a/tests/pathfindingManager.test.js
+++ b/tests/pathfindingManager.test.js
@@ -29,6 +29,27 @@ test('단순 경로 탐색', () => {
     assert.deepStrictEqual(path, [{x:1,y:0},{x:2,y:0}]);
 });
 
+test('같은 지점은 경로 없음', () => {
+    const mapManager = {
+        map: [
+            [0,0,0],
+            [0,0,0],
+            [0,0,0]
+        ],
+        width:3,
+        height:3,
+        tileSize:1,
+        tileTypes:{FLOOR:0,WALL:1},
+        isWallAt(x,y){
+            const tx=Math.floor(x/1); const ty=Math.floor(y/1);
+            return this.map[ty][tx]===this.tileTypes.WALL;
+        }
+    };
+    const pfManager = new PathfindingManager(mapManager);
+    const path = pfManager.findPath(1,1,1,1);
+    assert.deepStrictEqual(path, []);
+});
+
 test('동적 장애물 회피', () => {
     const mapManager = {
         map: [


### PR DESCRIPTION
## Summary
- avoid unnecessary path search when start and end tiles are identical
- test pathfinding for identical start and end positions
- log the change in codex's room

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853bb444bcc83278ee1fc0e4cf41528