### PR TITLE
Implement Aquarium map and manager

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -1,0 +1,21 @@
+// src/aquariumMap.js
+// Specialized map where new features can be placed and tested
+import { MapManager } from './map.js';
+
+export class AquariumMapManager extends MapManager {
+    constructor(seed) {
+        super(seed);
+        this.name = 'aquarium';
+    }
+
+    _generateMaze() {
+        // Aquarium map is a large open area for testing new features
+        const map = Array.from({ length: this.height }, () => Array(this.width).fill(this.tileTypes.WALL));
+        for (let y = 1; y < this.height - 1; y++) {
+            for (let x = 1; x < this.width - 1; x++) {
+                map[y][x] = this.tileTypes.FLOOR;
+            }
+        }
+        return map;
+    }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -9,6 +9,8 @@ import { CombatLogManager, SystemLogManager } from './managers/logManager.js';
 import { CombatCalculator } from './combat.js';
 import { TagManager } from './managers/tagManager.js';
 import { MapManager } from './map.js';
+import { AquariumMapManager } from './aquariumMap.js';
+import { AquariumManager, AquariumInspector } from './managers/aquariumManager.js';
 import * as Managers from './managers/index.js'; // managers/index.js에서 모든 매니저를 한 번에 불러옴
 import { AssetLoader } from './assetLoader.js';
 import { MetaAIManager, STRATEGY } from './managers/ai-managers.js';
@@ -57,7 +59,8 @@ export class Game {
         this.systemLogManager = new SystemLogManager(this.eventManager);
         this.tagManager = new TagManager();
         this.combatCalculator = new CombatCalculator(this.eventManager, this.tagManager);
-        this.mapManager = new MapManager();
+        // Player begins in the Aquarium map for feature testing
+        this.mapManager = new AquariumMapManager();
         this.saveLoadManager = new SaveLoadManager();
         this.turnManager = new TurnManager();
         this.narrativeManager = new NarrativeManager();
@@ -95,6 +98,15 @@ export class Game {
         // UIManager가 mercenaryManager에 접근할 수 있도록 설정
         this.uiManager.mercenaryManager = this.mercenaryManager;
         this.metaAIManager = new MetaAIManager(this.eventManager);
+        this.aquariumManager = new AquariumManager(
+            this.eventManager,
+            this.monsterManager,
+            this.itemManager,
+            this.mapManager,
+            this.factory,
+            this.itemFactory
+        );
+        this.aquariumInspector = new AquariumInspector(this.aquariumManager);
 
         for (let i = 0; i < 20; i++) {
             const pos = this.mapManager.getRandomFloorPosition();
@@ -104,6 +116,14 @@ export class Game {
                 this.itemManager.addItem(new Item(pos.x, pos.y, this.mapManager.tileSize, itemName, assets[itemName]));
             }
         }
+
+        // example feature: spawn a monster for poison debuff testing
+        this.aquariumManager.addTestingFeature({
+            type: 'monster',
+            image: assets.monster,
+            baseStats: { }
+        });
+        this.aquariumInspector.run();
 
         this.playerGroup = this.metaAIManager.createGroup('player_party', STRATEGY.AGGRESSIVE);
         this.monsterGroup = this.metaAIManager.createGroup('dungeon_monsters', STRATEGY.AGGRESSIVE);

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -1,0 +1,52 @@
+// src/managers/aquariumManager.js
+// Manages patches and features placed on the Aquarium map
+export class AquariumManager {
+    constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory) {
+        this.eventManager = eventManager;
+        this.monsterManager = monsterManager;
+        this.itemManager = itemManager;
+        this.mapManager = mapManager;
+        this.charFactory = charFactory;
+        this.itemFactory = itemFactory;
+        this.features = [];
+    }
+
+    addTestingFeature(feature) {
+        this.features.push(feature);
+        if (feature.type === 'monster') {
+            const pos = this.mapManager.getRandomFloorPosition();
+            if (pos) {
+                const monster = this.charFactory.create('monster', {
+                    x: pos.x,
+                    y: pos.y,
+                    tileSize: this.mapManager.tileSize,
+                    groupId: 'dungeon_monsters',
+                    image: feature.image,
+                    baseStats: feature.baseStats || {}
+                });
+                this.monsterManager.monsters.push(monster);
+            }
+        } else if (feature.type === 'item') {
+            const pos = this.mapManager.getRandomFloorPosition();
+            if (pos) {
+                const item = this.itemFactory.create(feature.itemId, pos.x, pos.y, this.mapManager.tileSize);
+                if (item) this.itemManager.addItem(item);
+            }
+        }
+    }
+
+    inspectFeatures() {
+        return this.features.length > 0;
+    }
+}
+
+export class AquariumInspector {
+    constructor(aquariumManager) {
+        this.aquariumManager = aquariumManager;
+    }
+
+    run() {
+        return this.aquariumManager.inspectFeatures();
+    }
+}
+

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -1,0 +1,27 @@
+import { AquariumMapManager } from '../src/aquariumMap.js';
+import { AquariumManager, AquariumInspector } from '../src/managers/aquariumManager.js';
+import { CharacterFactory } from '../src/factory.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { MonsterManager, ItemManager } from '../src/managers/managers.js';
+import { describe, test, assert } from './helpers.js';
+
+const assets = { monster:{} };
+
+describe('Aquarium', () => {
+    test('Aquarium map has open floor', () => {
+        const m = new AquariumMapManager(1);
+        assert.strictEqual(m.map[1][1], m.tileTypes.FLOOR);
+    });
+
+    test('Manager adds feature and inspector passes', () => {
+        const eventManager = new EventManager();
+        const monsterManager = new MonsterManager(0, new AquariumMapManager(), assets, eventManager, new CharacterFactory(assets));
+        const itemManager = new ItemManager();
+        const factory = new CharacterFactory(assets);
+        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} });
+        aquariumManager.addTestingFeature({ type:'monster', image:{} });
+        const inspector = new AquariumInspector(aquariumManager);
+        assert.ok(inspector.run(), 'inspection fails');
+        assert.strictEqual(monsterManager.monsters.length, 1);
+    });
+});


### PR DESCRIPTION
## Summary
- create `AquariumMapManager` as an open testing area
- implement `AquariumManager` and `AquariumInspector` for patch features
- update `Game` to start on the Aquarium map and spawn an example monster
- add tests for the new Aquarium system

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c12e8ca4832795616ffbd5c4d227