### PR TITLE
Add ParticleDecoratorManager

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -95,6 +95,9 @@ export class Game {
         this.motionManager = new Managers.MotionManager(this.mapManager, this.pathfindingManager);
         this.movementManager = new MovementManager(this.mapManager);
         this.fogManager = new FogManager(this.mapManager.width, this.mapManager.height);
+        this.particleDecoratorManager = new Managers.ParticleDecoratorManager();
+        this.particleDecoratorManager.setManagers(this.vfxManager, this.mapManager);
+        this.particleDecoratorManager.init();
         // UIManager가 mercenaryManager에 접근할 수 있도록 설정
         this.uiManager.mercenaryManager = this.mercenaryManager;
         this.metaAIManager = new MetaAIManager(this.eventManager);

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -14,6 +14,7 @@ import { ProjectileManager } from './projectileManager.js';
 import { MotionManager } from './motionManager.js';
 import { MovementManager } from './movementManager.js';
 import { EquipmentRenderManager } from './equipmentRenderManager.js';
+import { ParticleDecoratorManager } from './particleDecoratorManager.js';
 // 파일 기반 로거는 Node 환경 전용이라 기본 묶음에서 제외한다
 // import { FileLogManager } from './fileLogManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
@@ -32,4 +33,5 @@ export {
     MotionManager,
     MovementManager,
     EquipmentRenderManager,
+    ParticleDecoratorManager,
 };

--- a/src/managers/particleDecoratorManager.js
+++ b/src/managers/particleDecoratorManager.js
@@ -1,0 +1,38 @@
+export class ParticleDecoratorManager {
+    constructor(eventManager = null, assets = null, factory = null) {
+        this.vfxManager = null;
+        this.mapManager = null;
+        this.emitters = [];
+        this.initialized = false;
+        console.log('[ParticleDecoratorManager] Initialized');
+    }
+
+    setManagers(vfxManager, mapManager) {
+        this.vfxManager = vfxManager;
+        this.mapManager = mapManager;
+    }
+
+    init() {
+        if (this.initialized) return;
+        if (!this.vfxManager || !this.mapManager) return;
+        for (const room of this.mapManager.rooms) {
+            const centerX = (room.x + room.width / 2) * this.mapManager.tileSize;
+            const centerY = (room.y + room.height / 2) * this.mapManager.tileSize;
+            const emitter = this.vfxManager.addEmitter(centerX, centerY, {
+                spawnRate: 1,
+                duration: -1,
+                particleOptions: { color: 'rgba(255,255,255,0.3)', speed: 0.5, gravity: 0 }
+            });
+            this.emitters.push(emitter);
+        }
+        this.initialized = true;
+    }
+
+    clear() {
+        for (const emitter of this.emitters) {
+            this.vfxManager.removeEmitter(emitter);
+        }
+        this.emitters = [];
+        this.initialized = false;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ParticleDecoratorManager` to spawn ambient particle emitters
- expose the new manager in the managers index
- initialize the decorator manager during game setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c346176883278b9afba7bf0b33ff