### PR TITLE
Update aquarium map to maze

### DIFF
--- a/src/aquariumMap.js
+++ b/src/aquariumMap.js
@@ -6,16 +6,14 @@ export class AquariumMapManager extends MapManager {
     constructor(seed) {
         super(seed);
         this.name = 'aquarium';
+        // wider passages help observe pathfinding for mercenaries and monsters
+        this.corridorWidth = 8;
+        // regenerate with the new corridor width
+        this.map = this._generateMaze();
     }
 
     _generateMaze() {
-        // Aquarium map is a large open area for testing new features
-        const map = Array.from({ length: this.height }, () => Array(this.width).fill(this.tileTypes.WALL));
-        for (let y = 1; y < this.height - 1; y++) {
-            for (let x = 1; x < this.width - 1; x++) {
-                map[y][x] = this.tileTypes.FLOOR;
-            }
-        }
-        return map;
+        // use the base maze generation but with a larger corridor width
+        return super._generateMaze();
     }
 }

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -8,9 +8,11 @@ import { describe, test, assert } from './helpers.js';
 const assets = { monster:{} };
 
 describe('Aquarium', () => {
-    test('Aquarium map has open floor', () => {
+    test('Aquarium map uses a wide maze layout', () => {
         const m = new AquariumMapManager(1);
-        assert.strictEqual(m.map[1][1], m.tileTypes.FLOOR);
+        assert.ok(m.corridorWidth >= 8, 'corridor width should be wide');
+        const wallCount = m.countTiles(m.tileTypes.WALL);
+        assert.ok(wallCount > 0 && wallCount < m.width * m.height, 'maze should contain walls and floors');
     });
 
     test('Manager adds feature and inspector passes', () => {


### PR DESCRIPTION
## Summary
- regenerate the Aquarium map as a maze with extra-wide corridors
- add constructor logic to rebuild with width 8
- adjust tests to validate the new labyrinth map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c4acf5c4832794944d0f05cab9f9