### PR TITLE
Add bubble emitter feature to aquarium

### DIFF
--- a/VFX_GUIDE.md
+++ b/VFX_GUIDE.md
@@ -38,3 +38,7 @@
 4. **유도형** : `addHomingBurst`는 `target`을 지정하여 파티클들이 해당 지점을 향해 서서히 모입니다.
 
 위 기능들은 모두 `vfxManager` 인스턴스를 통해 호출할 수 있습니다.
+
+## 신규 효과: Bubble Emitter
+- `AquariumManager`의 `bubble` 피처가 호출되면 맵의 임의 위치에 거품 파티클 이미터가 생성됩니다.
+- 해당 이미터는 `spawnRate`를 조절해 지속적으로 파티클을 분출하며, `gravity` 값을 음수로 주어 위로 떠오르는 움직임을 연출합니다.

--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -32,3 +32,8 @@
 ## 세션 7
 - `PathfindingManager.findPath`가 시작과 끝이 같을 때 바로 빈 배열을 반환하도록 수정.
 - `pathfindingManager.test.js`에 해당 케이스 테스트 추가.
+
+## 세션 8
+- 수족관 맵에서 환경 효과를 테스트하기 위해 `bubble` 피처 타입을 추가.
+- `AquariumManager`가 `bubble` 타입을 처리하여 VFX 이미터를 배치하도록 수정.
+- `aquarium.test.js`에 거품 이미터 생성 여부 테스트 추가.

--- a/src/game.js
+++ b/src/game.js
@@ -107,7 +107,8 @@ export class Game {
             this.itemManager,
             this.mapManager,
             this.factory,
-            this.itemFactory
+            this.itemFactory,
+            this.vfxManager
         );
         this.aquariumInspector = new AquariumInspector(this.aquariumManager);
 

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -1,13 +1,14 @@
 // src/managers/aquariumManager.js
 // Manages patches and features placed on the Aquarium map
 export class AquariumManager {
-    constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory) {
+    constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory, vfxManager = null) {
         this.eventManager = eventManager;
         this.monsterManager = monsterManager;
         this.itemManager = itemManager;
         this.mapManager = mapManager;
         this.charFactory = charFactory;
         this.itemFactory = itemFactory;
+        this.vfxManager = vfxManager;
         this.features = [];
     }
 
@@ -31,6 +32,24 @@ export class AquariumManager {
             if (pos) {
                 const item = this.itemFactory.create(feature.itemId, pos.x, pos.y, this.mapManager.tileSize);
                 if (item) this.itemManager.addItem(item);
+            }
+        } else if (feature.type === 'bubble' && this.vfxManager) {
+            const pos = this.mapManager.getRandomFloorPosition();
+            if (pos) {
+                const emitter = this.vfxManager.addEmitter(
+                    pos.x + this.mapManager.tileSize / 2,
+                    pos.y + this.mapManager.tileSize / 2,
+                    {
+                        spawnRate: feature.spawnRate || 2,
+                        duration: -1,
+                        particleOptions: {
+                            color: feature.color || 'rgba(200,200,255,0.7)',
+                            gravity: feature.gravity !== undefined ? feature.gravity : -0.05,
+                            speed: feature.speed || 0.5,
+                        },
+                    }
+                );
+                feature.emitter = emitter;
             }
         }
     }

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -3,6 +3,7 @@ import { AquariumManager, AquariumInspector } from '../src/managers/aquariumMana
 import { CharacterFactory } from '../src/factory.js';
 import { EventManager } from '../src/managers/eventManager.js';
 import { MonsterManager, ItemManager } from '../src/managers/managers.js';
+import { VFXManager } from '../src/managers/vfxManager.js';
 import { describe, test, assert } from './helpers.js';
 
 const assets = { monster:{} };
@@ -18,12 +19,24 @@ describe('Aquarium', () => {
     test('Manager adds feature and inspector passes', () => {
         const eventManager = new EventManager();
         const monsterManager = new MonsterManager(0, new AquariumMapManager(), assets, eventManager, new CharacterFactory(assets));
-        const itemManager = new ItemManager();
+        const itemManager = new ItemManager(0, monsterManager.mapManager, assets);
         const factory = new CharacterFactory(assets);
-        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} });
+        const vfx = new VFXManager();
+        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx);
         aquariumManager.addTestingFeature({ type:'monster', image:{} });
         const inspector = new AquariumInspector(aquariumManager);
         assert.ok(inspector.run(), 'inspection fails');
         assert.strictEqual(monsterManager.monsters.length, 1);
+    });
+
+    test('Bubble feature spawns emitter', () => {
+        const eventManager = new EventManager();
+        const monsterManager = new MonsterManager(0, new AquariumMapManager(), assets, eventManager, new CharacterFactory(assets));
+        const itemManager = new ItemManager(0, monsterManager.mapManager, assets);
+        const factory = new CharacterFactory(assets);
+        const vfx = new VFXManager();
+        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx);
+        aquariumManager.addTestingFeature({ type: 'bubble' });
+        assert.strictEqual(vfx.emitters.length, 1);
     });
 });


### PR DESCRIPTION
## Summary
- update `AquariumManager` to support `bubble` features
- wire VFX manager to aquarium manager
- test bubble emitters in `aquarium.test.js`
- log the change in Codex's Room dev log and VFX guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c6ee86308327b4956ba91d7ff2f7