### PR TITLE
Add wizard mercenary class

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
                 <button id="hire-mercenary">전사 용병 고용 (50골드)</button>
                 <button id="hire-archer">궁수 용병 고용 (50골드)</button>
                 <button id="hire-healer">힐러 용병 고용 (50골드)</button>
+                <button id="hire-wizard">마법사 용병 고용 (50골드)</button>
                 <button id="save-game-btn">게임 저장</button>
             </div>
         </div>

--- a/src/ai.js
+++ b/src/ai.js
@@ -207,3 +207,8 @@ export class RangedAI extends AIArchetype {
         return { type: 'idle' };
     }
 }
+
+// --- 마법사형 AI (현재는 RangedAI와 동일하게 동작)
+export class WizardAI extends RangedAI {
+    // 추가적인 마법사 전용 로직이 들어갈 수 있습니다
+}

--- a/src/data/jobs.js
+++ b/src/data/jobs.js
@@ -36,5 +36,19 @@ export const JOBS = {
             attackPower: 10,
         }
     },
+    wizard: {
+        name: '마법사',
+        description: '원소 마법으로 적을 제압하는 전문가입니다.',
+        stats: {
+            strength: 2,
+            agility: 4,
+            endurance: 3,
+            focus: 9,
+            intelligence: 8,
+            movement: 10,
+            hp: 24,
+            attackPower: 12,
+        }
+    },
 };
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -8,7 +8,7 @@ import { ITEMS } from './data/items.js';
 import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
-import { RangedAI, HealerAI } from './ai.js';
+import { RangedAI, HealerAI, WizardAI } from './ai.js';
 import { MBTI_TYPES } from './data/mbti.js';
 
 export class CharacterFactory {
@@ -69,6 +69,10 @@ export class CharacterFactory {
                 } else if (config.jobId === 'healer') {
                     merc.skills.push(SKILLS.heal.id);
                     merc.ai = new HealerAI();
+                } else if (config.jobId === 'wizard') {
+                    const mageSkill = Math.random() < 0.5 ? SKILLS.fireball.id : SKILLS.iceball.id;
+                    merc.skills.push(mageSkill);
+                    merc.ai = new WizardAI();
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);

--- a/src/game.js
+++ b/src/game.js
@@ -261,6 +261,29 @@ export class Game {
             };
         }
 
+        const wizardBtn = document.getElementById('hire-wizard');
+        if (wizardBtn) {
+            wizardBtn.onclick = () => {
+                if (this.gameState.gold >= 50) {
+                    this.gameState.gold -= 50;
+                    const newMerc = this.mercenaryManager.hireMercenary(
+                        'wizard',
+                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.y,
+                        this.mapManager.tileSize,
+                        'player_party'
+                    );
+
+                    if (newMerc) {
+                        this.playerGroup.addMember(newMerc);
+                        this.eventManager.publish('log', { message: `마법사 용병을 고용했습니다.` });
+                    }
+                } else {
+                    this.eventManager.publish('log', { message: `골드가 부족합니다.` });
+                }
+            };
+        }
+
         const saveBtn = document.getElementById('save-game-btn');
         if (saveBtn) {
             saveBtn.onclick = () => {

--- a/tests/mercenarySkills.test.js
+++ b/tests/mercenarySkills.test.js
@@ -40,4 +40,14 @@ test('궁수 스킬 부여 - hawk_eye', () => {
     assert.strictEqual(merc.skills[0], SKILLS.hawk_eye.id);
 });
 
+test('마법사 스킬 부여 - fireball', () => {
+    const merc = createMerc('wizard', 0.1);
+    assert.strictEqual(merc.skills[0], SKILLS.fireball.id);
+});
+
+test('마법사 스킬 부여 - iceball', () => {
+    const merc = createMerc('wizard', 0.9);
+    assert.strictEqual(merc.skills[0], SKILLS.iceball.id);
+});
+
 });


### PR DESCRIPTION
## Summary
- introduce `wizard` job with stats
- support hiring wizard mercenaries in the UI and game logic
- give wizards Fireball or Iceball and assign WizardAI
- implement `WizardAI` subclass
- test wizard mercenary skill assignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ca65ef888327b901ecc4fd47be63