### PR TITLE
Add teleport skill functionality

### DIFF
--- a/GAMEPLAY_GUIDE.md
+++ b/GAMEPLAY_GUIDE.md
@@ -69,6 +69,8 @@ Click the buttons in the *Hire Mercenary* panel to recruit warriors, archers, he
 Spend collected gold in the shop to purchase items. Bought gear is placed in your inventory and can boost your stats when equipped. All skills are unlocked from the start and can be assigned to the **Skill1** and **Skill2** slots.
 When defining skills, include a numeric `cooldown` property. Passive or always-available skills should set it to `0`.
 
+The newly added **Teleport** skill lets you mark your current position and return to it later. Use it once to save your location, again to warp back and a third time to return to where you warped from.
+
 ### Mercenary Skills
 
 Each mercenary receives one random skill upon hiring. Using that skill costs the

--- a/index.html
+++ b/index.html
@@ -188,6 +188,7 @@
     <div id="skill-bar">
         <div class="skill-slot" data-slot-index="0"><span>1</span></div>
         <div class="skill-slot" data-slot-index="1"><span>2</span></div>
+        <div class="skill-slot" data-slot-index="2"><span>3</span></div>
     </div>
 
     <div id="tooltip" class="tooltip hidden"></div>

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -243,4 +243,13 @@ export const SKILLS = {
         tags: ['skill', 'debuff', 'resist_down', 'enemy', '디버프'],
         effects: { target: ['resist_down'] },
     },
+    teleport: {
+        id: 'teleport',
+        name: '텔레포트',
+        description: '위치를 저장하고 다시 그 위치로 순간 이동합니다.',
+        manaCost: 2,
+        cooldown: 60,
+        tags: ['skill', 'utility', 'teleport'],
+        teleport: true,
+    },
 };

--- a/src/entities.js
+++ b/src/entities.js
@@ -35,6 +35,10 @@ class Entity {
             accessory1: null,
             accessory2: null,
         };
+
+        // 텔레포트 스킬 사용을 위한 위치 저장용 프로퍼티
+        this.teleportSavedPos = null;
+        this.teleportReturnPos = null;
     }
 
     get speed() { return this.stats.get('movementSpeed'); }

--- a/src/factory.js
+++ b/src/factory.js
@@ -52,6 +52,7 @@ export class CharacterFactory {
                 const player = new Player(finalConfig);
                 player.skills.push(SKILLS.fireball.id);
                 player.skills.push(SKILLS.iceball.id);
+                player.skills.push(SKILLS.teleport.id);
                 return player;
             case 'mercenary':
                 if (config.jobId && JOBS[config.jobId]) {

--- a/src/game.js
+++ b/src/game.js
@@ -404,6 +404,10 @@ export class Game {
             eventManager.publish('log', { message: `${caster.constructor.name} (이)가 ${skill.name} 스킬 사용!`, color: 'aqua' });
             this.vfxManager.castEffect(caster, skill);
 
+            if (skill.teleport) {
+                this.handleTeleportSkill(caster);
+            }
+
             if (skill.tags.includes('attack')) {
                 const range = skill.range || Infinity;
                 const nearestEnemy = this.findNearestEnemy(caster, monsterManager.monsters, range);
@@ -661,6 +665,24 @@ export class Game {
             player.mp = player.maxMp;
             this.gameState.statPoints += 5;
             this.eventManager.publish('level_up', { player: player, level: stats.get('level') });
+        }
+    }
+
+    handleTeleportSkill(caster) {
+        if (!caster.teleportSavedPos) {
+            caster.teleportSavedPos = { x: caster.x, y: caster.y };
+            this.eventManager.publish('log', { message: '🌀 위치를 저장했습니다.' });
+        } else if (!caster.teleportReturnPos) {
+            caster.teleportReturnPos = { x: caster.x, y: caster.y };
+            caster.x = caster.teleportSavedPos.x;
+            caster.y = caster.teleportSavedPos.y;
+            this.eventManager.publish('log', { message: '🌀 저장된 위치로 이동했습니다.' });
+        } else {
+            const { x, y } = caster.teleportReturnPos;
+            caster.teleportReturnPos = null;
+            caster.x = x;
+            caster.y = y;
+            this.eventManager.publish('log', { message: '🌀 이전 위치로 돌아왔습니다.' });
         }
     }
 

--- a/tests/teleportSkill.test.js
+++ b/tests/teleportSkill.test.js
@@ -1,0 +1,12 @@
+import { CharacterFactory } from '../src/factory.js';
+import { describe, test, assert } from './helpers.js';
+import { SKILLS } from '../src/data/skills.js';
+
+describe('Teleport Skill', () => {
+  test('플레이어가 텔레포트 스킬을 보유한다', () => {
+    const assets = { player:{} };
+    const factory = new CharacterFactory(assets);
+    const player = factory.create('player', { x:0, y:0, tileSize:1, groupId:'g' });
+    assert.ok(player.skills.includes(SKILLS.teleport.id));
+  });
+});


### PR DESCRIPTION
## Summary
- add new Teleport skill data
- give player the Teleport skill and show a third skill slot
- implement teleport behaviour in `Game` and add position properties on entities
- document the skill in the gameplay guide
- test player creation includes Teleport skill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853dab0ffa08327bfc110809fe8e159