### PR TITLE
Fix bow range for mercenaries

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -14,7 +14,7 @@ export const ITEMS = {
         damageDice: '1d6',
         tags: ['ranged', 'bow'],
         imageKey: 'bow',
-        stats: { attackPower: 2 },
+        stats: { attackPower: 2, attackRange: 384 },
     },
 
     // 방어구


### PR DESCRIPTION
## Summary
- expand `long_bow` item stats with larger `attackRange`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e57ad6788327b1b90b4b5f4feb8f