### PR TITLE
Add healing effect for healer skill

### DIFF
--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -15,6 +15,7 @@ export const SKILLS = {
         id: 'heal',
         name: '치유',
         description: '대상을 회복시켜 체력을 되찾게 합니다.',
+        healAmount: 10,
         manaCost: 10,
         cooldown: 90,
         tags: ['skill', 'support', 'healing', 'magic', '회복', '마법'],

--- a/src/game.js
+++ b/src/game.js
@@ -50,6 +50,7 @@ export class Game {
         this.loader.loadImage('fire-ball', 'assets/images/fire-ball.png');
         this.loader.loadImage('ice-ball', 'assets/images/ice-ball-effect.png');
         this.loader.loadImage('strike-effect', 'assets/images/strike-effect.png');
+        this.loader.loadImage('healing-effect', 'assets/images/healing-effect.png');
 
         this.loader.onReady(assets => this.init(assets));
     }
@@ -414,7 +415,28 @@ export class Game {
             this.vfxManager.castEffect(caster, skill);
 
             if (skill.tags && (skill.tags.includes('healing') || skill.tags.includes('회복'))) {
-                this.particleDecoratorManager.playHealingEffect(target || caster);
+                const healTarget = target || caster;
+                const amount = skill.healAmount || 10;
+                const prevHp = healTarget.hp;
+                healTarget.hp = Math.min(healTarget.maxHp, healTarget.hp + amount);
+                const healed = healTarget.hp - prevHp;
+                if (healed > 0) {
+                    eventManager.publish('log', { message: `${healTarget.constructor.name}의 체력이 ${healed} 회복되었습니다.`, color: 'lime' });
+                }
+                this.particleDecoratorManager.playHealingEffect(healTarget);
+                const img = assets['healing-effect'];
+                if (img) {
+                    this.vfxManager.addSpriteEffect(
+                        img,
+                        healTarget.x + healTarget.width / 2,
+                        healTarget.y + healTarget.height / 2,
+                        {
+                            width: healTarget.width,
+                            height: healTarget.height,
+                            blendMode: 'screen'
+                        }
+                    );
+                }
             }
 
             if (skill.teleport) {


### PR DESCRIPTION
## Summary
- load healing-effect image
- implement healing logic when heal skill is used
- display healing sprite effect on the healed target
- add `healAmount` to heal skill data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f91e8d4883279ef989e7cc804b80