### PR TITLE
Add arrow projectile support

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -272,6 +272,8 @@ export class Projectile {
         // 밝게 그려야 하는 마법 투사체의 경우 blendMode를 'lighter'로 설정할 수 있다
         this.blendMode = config.blendMode || null;
 
+        this.rotation = 0;
+
         this.vfxManager = config.vfxManager || null;
         this.enableGlow = config.enableGlow || false;
         this.isDead = false;
@@ -293,6 +295,8 @@ export class Projectile {
         const dy = this.target.y - this.y;
         const distance = Math.hypot(dx, dy);
 
+        this.rotation = Math.atan2(dy, dx);
+
         if (distance < this.speed) {
             this.isDead = true;
             return { collided: true, target: this.target };
@@ -313,6 +317,9 @@ export class Projectile {
 
         if (this.image) {
             ctx.drawImage(this.image, this.x, this.y, this.width, this.height);
+            ctx.translate(this.x + this.width / 2, this.y + this.height / 2);
+            ctx.rotate(this.rotation);
+            ctx.drawImage(this.image, -this.width / 2, -this.height / 2, this.width, this.height);
         }
 
         ctx.restore();

--- a/src/game.js
+++ b/src/game.js
@@ -46,6 +46,7 @@ export class Game {
         this.loader.loadImage('potion', 'assets/potion.png');
         this.loader.loadImage('sword', 'assets/images/shortsword.png');
         this.loader.loadImage('bow', 'assets/images/bow.png');
+        this.loader.loadImage('arrow', 'assets/images/arrow.png');
         this.loader.loadImage('leather_armor', 'assets/images/leatherarmor.png');
         this.loader.loadImage('fire-ball', 'assets/images/fire-ball.png');
         this.loader.loadImage('ice-ball', 'assets/images/ice-ball-effect.png');
@@ -630,7 +631,7 @@ export class Game {
             this.itemManager.removeItem(itemToPick);
         }
         this.fogManager.update(player, mapManager);
-        const context = { eventManager, player, mapManager, monsterManager, mercenaryManager, pathfindingManager, movementManager: this.movementManager };
+        const context = { eventManager, player, mapManager, monsterManager, mercenaryManager, pathfindingManager, movementManager: this.movementManager, projectileManager: this.projectileManager };
         metaAIManager.update(context);
         this.projectileManager.update();
         this.vfxManager.update();

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -58,6 +58,14 @@ export class MetaAIManager {
                 if (entity.attackCooldown === 0) {
                     // 공격 이벤트를 발행
                     eventManager.publish('entity_attack', { attacker: entity, defender: action.target });
+                    const weaponTags = entity.equipment?.weapon?.tags || [];
+                    const isRanged = weaponTags.includes('ranged') || weaponTags.includes('bow');
+                    if (isRanged && context.projectileManager) {
+                        const projSkill = { projectile: 'arrow', damage: entity.attackPower };
+                        context.projectileManager.create(entity, action.target, projSkill);
+                    } else {
+                        eventManager.publish('entity_attack', { attacker: entity, defender: action.target });
+                    }
                     const baseCd = 60;
                     entity.attackCooldown = Math.max(1, Math.round(baseCd / (entity.attackSpeed || 1)));
                 }

--- a/src/managers/projectileManager.js
+++ b/src/managers/projectileManager.js
@@ -12,25 +12,31 @@ export class ProjectileManager {
     create(caster, target, skill) {
         const keyMap = {
             fireball: 'fire-ball',
-            iceball: 'ice-ball'
+            iceball: 'ice-ball',
+            arrow: 'arrow'
         };
         const imageKey = keyMap[skill.projectile] || skill.projectile;
 
+        const isArrow = skill.projectile === 'arrow';
+
         const config = {
-            x: caster.x,
-            y: caster.y,
+            x: caster.x + caster.width / 2,
+            y: caster.y + caster.height / 2,
             target: target,
             caster: caster,
             damage: skill.damage,
             image: this.assets[imageKey],
-            width: 64,
-            height: 64,
-            // 파이어볼 및 아이스볼 투사체는 스크린 블렌드 모드로 표현
-            blendMode: 'screen',
-            enableGlow: true,
+            width: isArrow ? 32 : 64,
+            height: isArrow ? 32 : 64,
+            blendMode: isArrow ? null : 'screen',
+            enableGlow: !isArrow,
             vfxManager: this.vfxManager,
         };
-        this.projectiles.push(new Projectile(config));
+        const projectile = new Projectile(config);
+        this.projectiles.push(projectile);
+        if (isArrow && this.vfxManager) {
+            this.vfxManager.addArrowTrail(projectile);
+        }
     }
 
     update() {


### PR DESCRIPTION
## Summary
- implement rotation for projectiles and draw oriented sprite
- load arrow asset and forward `projectileManager` in AI context
- trigger arrow projectiles for ranged attacks
- support arrow-specific logic in `ProjectileManager`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853fd68b6cc832786ca70754af5d202