### PR TITLE
Add death animation handled by VFXManager

### DIFF
--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -26,7 +26,7 @@ export class MonsterManager {
     }
 
     render(ctx) {
-        for (const monster of this.monsters) {
+        for (const monster of this.monsters.filter(m => !m.isDying)) {
             if (monster.render) monster.render(ctx);
         }
     }

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -21,7 +21,7 @@ describe('Aquarium', () => {
         const monsterManager = new MonsterManager(0, new AquariumMapManager(), assets, eventManager, new CharacterFactory(assets));
         const itemManager = new ItemManager(0, monsterManager.mapManager, assets);
         const factory = new CharacterFactory(assets);
-        const vfx = new VFXManager();
+        const vfx = new VFXManager(eventManager);
         const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx);
         aquariumManager.addTestingFeature({ type:'monster', image:{} });
         const inspector = new AquariumInspector(aquariumManager);
@@ -34,7 +34,7 @@ describe('Aquarium', () => {
         const monsterManager = new MonsterManager(0, new AquariumMapManager(), assets, eventManager, new CharacterFactory(assets));
         const itemManager = new ItemManager(0, monsterManager.mapManager, assets);
         const factory = new CharacterFactory(assets);
-        const vfx = new VFXManager();
+        const vfx = new VFXManager(eventManager);
         const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx);
         aquariumManager.addTestingFeature({ type: 'bubble' });
         assert.strictEqual(vfx.emitters.length, 1);


### PR DESCRIPTION
## Summary
- extend `VFXManager` with death animation functionality
- trigger death animations from game events
- defer monster removal until animation ends
- stop rendering dying monsters
- adjust tests for updated `VFXManager` constructor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540057f538832783b7e88303498bff