### PR TITLE
Enhance UI theme with shared border frames

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="top-menu-bar">
+    <div id="top-menu-bar" class="ui-frame">
         <button class="menu-btn" data-panel-id="inventory">인벤토리</button>
         <button class="menu-btn" data-panel-id="mercenary-panel">용병 부대</button>
     </div>
@@ -18,9 +18,9 @@
         <canvas id="vfx-canvas" class="game-layer"></canvas>
         <canvas id="weather-canvas" class="game-layer"></canvas>
     </div>
-    <canvas id="minimap-canvas"></canvas>
+    <canvas id="minimap-canvas" class="ui-frame"></canvas>
 
-    <div id="ui-panel">
+    <div id="ui-panel" class="ui-frame">
         <h2>플레이어 상태</h2>
         <div class="stats-content-box">
             <div id="player-stats-container">
@@ -109,15 +109,15 @@
             </div>
         </div>
     </div>
-    <div id="combat-log-panel">
+    <div id="combat-log-panel" class="ui-frame">
         <div id="combat-log-content"></div>
     </div>
 
-    <div id="system-log-panel">
+    <div id="system-log-panel" class="ui-frame">
         <div class="log-title">-- SYSTEM LOG --</div>
         <div id="system-log-content"></div>
     </div>
-    <div id="mercenary-detail-panel" class="modal-panel hidden">
+    <div id="mercenary-detail-panel" class="modal-panel ui-frame hidden">
         <button id="close-merc-detail-btn" class="close-btn">X</button>
         <h2 id="merc-detail-name">용병 이름</h2>
         <div class="stats-content-box">
@@ -143,14 +143,14 @@
         </div>
     </div>
 
-    <div id="equipment-target-panel" class="modal-panel hidden">
+    <div id="equipment-target-panel" class="modal-panel ui-frame hidden">
         <button id="close-equip-target-btn" class="close-btn">X</button>
         <h2>누구에게 장착하시겠습니까?</h2>
         <div id="equipment-target-list">
         </div>
     </div>
 
-    <div id="inventory-panel" class="modal-panel wide hidden">
+    <div id="inventory-panel" class="modal-panel wide ui-frame hidden">
         <button class="close-btn" data-panel-id="inventory">X</button>
         <h2>🎒 인벤토리</h2>
         <div class="inventory-container">
@@ -177,7 +177,7 @@
         </div>
     </div>
 
-    <div id="mercenary-panel" class="modal-panel wide hidden">
+    <div id="mercenary-panel" class="modal-panel wide ui-frame hidden">
         <button class="close-btn" data-panel-id="mercenary-panel">X</button>
         <h2>🗡️ 용병 부대</h2>
         <div id="mercenary-list"></div>
@@ -185,13 +185,13 @@
 
 
 
-    <div id="skill-bar">
+    <div id="skill-bar" class="ui-frame">
         <div class="skill-slot" data-slot-index="0"><span>1</span></div>
         <div class="skill-slot" data-slot-index="1"><span>2</span></div>
         <div class="skill-slot" data-slot-index="2"><span>3</span></div>
     </div>
 
-    <div id="tooltip" class="tooltip hidden"></div>
+    <div id="tooltip" class="tooltip ui-frame hidden"></div>
 
     <script type="module" src="main.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -23,9 +23,7 @@ body, html {
     left: 50%;
     transform: translateX(-50%);
     z-index: 120;
-    background: rgba(0, 0, 0, 0.5);
     padding: 5px 10px;
-    border-radius: 5px;
 }
 
 .menu-btn {
@@ -57,6 +55,22 @@ body, html {
 #weather-canvas     { z-index: 60; }
 
 /* 모든 UI 패널들은 캔버스 위에 위치 (z-index: 10) */
+
+/* 공통 UI 프레임 스타일 */
+.ui-frame {
+    border: 20px solid transparent;
+    border-image-source: url('assets/ui-border.png');
+    border-image-slice: 65 fill;
+    border-image-repeat: repeat;
+    background-image: url('assets/ui-bg.png');
+    background-color: #3a2d1d;
+    background-clip: padding-box;
+    box-shadow: 0 0 10px rgba(0,0,0,0.5);
+    font-family: sans-serif;
+    font-weight: bold;
+    color: #4a3b2a;
+}
+
 #ui-panel, #combat-log-panel, #system-log-panel, .modal-panel {
     position: fixed; /* 다른 요소 위에 올리기 위해 fixed 사용 */
     z-index: 100; /* 레이어 캔버스(최대 60) 위에 오도록 */
@@ -66,18 +80,7 @@ body, html {
     top: 20px;
     left: 20px;
     width: 250px;
-    border: 20px solid transparent;
-    border-image-source: url('assets/ui-border.png');
-    border-image-slice: 65 fill;
-    border-image-repeat: repeat;
-    background-image: url('assets/ui-bg.png');
-    background-color: #3a2d1d;
-    background-clip: padding-box;
     padding: 10px;
-    color: #4a3b2a;
-    font-weight: bold;
-    box-shadow: 0 0 10px rgba(0,0,0,0.5);
-    font-family: sans-serif;
 }
 
 .stat-line {
@@ -184,13 +187,9 @@ body, html {
     left: 20px;
     width: 400px;
     height: 150px;
-    background-color: rgba(0, 0, 0, 0.7);
-    border: 1px solid #555;
-    color: white;
     font-size: 12px;
     padding: 10px;
     overflow-y: auto;
-    border-radius: 5px;
 }
 
 #system-log-panel {
@@ -198,14 +197,11 @@ body, html {
     right: 20px;
     width: 400px;
     height: 150px;
-    background-color: rgba(10, 20, 40, 0.75);
-    border: 1px solid #007bff;
     color: #a2d2ff;
     font-family: 'Courier New', Courier, monospace;
     font-size: 11px;
     padding: 10px;
     overflow-y: auto;
-    border-radius: 5px;
     opacity: 0.7;
 }
 
@@ -224,11 +220,7 @@ body, html {
     transform: translate(-50%, -50%);
     width: 300px;
     z-index: 100;
-    border-image-slice: 65 fill;
-    background-clip: padding-box;
     padding: 10px;
-    font-weight: bold;
-    box-shadow: 0 0 20px rgba(0,0,0,0.8);
 }
 
 .modal-panel.hidden {
@@ -258,7 +250,6 @@ body, html {
     right: 20px;
     width: 200px;
     height: 150px;
-    border: 2px solid #555;
     background-color: black;
     z-index: 100;
 }
@@ -337,7 +328,6 @@ body, html {
 
 .tooltip {
     position: fixed;
-    background: rgba(0,0,0,0.8);
     color: #fff;
     padding: 6px 8px;
     border-radius: 4px;
@@ -351,7 +341,16 @@ body, html {
 .mp-bar-container { width: 100%; height: 10px; background-color: #333; border-radius: 3px; margin-top: 2px; }
 .mp-bar-fill { width: 100%; height: 100%; background-color: #3a7bd5; border-radius: 2px; }
 
-#skill-bar { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); display: flex; gap: 8px; z-index: 50; }
+#skill-bar {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 8px;
+    z-index: 50;
+    padding: 5px;
+}
 .skill-slot { width: 48px; height: 48px; border: 2px solid #888; background-color: #111; position: relative; }
 .skill-slot img { width: 100%; height: 100%; }
 .skill-slot > span { position: absolute; top: 2px; left: 4px; color: white; font-size: 10px; text-shadow: 1px 1px 2px black; }


### PR DESCRIPTION
## Summary
- create `.ui-frame` base style to reuse decorative border images
- refactor individual panels to remove inline border styling
- apply `.ui-frame` class to all existing UI panels for consistent look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854068ec3748327bef3c1d6f7a12f5e