### PR TITLE
Add item bobbing animation

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -237,6 +237,20 @@ export class Item {
         };
         this.stats = statsMap;
         this.sockets = [];
+
+        // Animation properties
+        this.baseY = y;
+        this.bobbingAngle = Math.random() * Math.PI * 2;
+        this.bobbingSpeed = 0.05;
+        this.bobbingAmount = 4;
+    }
+
+    update() {
+        this.bobbingAngle += this.bobbingSpeed;
+        if (this.bobbingAngle > Math.PI * 2) {
+            this.bobbingAngle -= Math.PI * 2;
+        }
+        this.y = this.baseY + Math.sin(this.bobbingAngle) * this.bobbingAmount;
     }
 
     render(ctx) {

--- a/src/game.js
+++ b/src/game.js
@@ -584,13 +584,14 @@ export class Game {
     }
 
     update = (deltaTime) => {
-        const { gameState, mercenaryManager, monsterManager, mapManager, inputHandler, effectManager, turnManager, pathfindingManager, metaAIManager, eventManager } = this;
+        const { gameState, mercenaryManager, monsterManager, itemManager, mapManager, inputHandler, effectManager, turnManager, pathfindingManager, metaAIManager, eventManager } = this;
         if (gameState.isPaused || gameState.isGameOver) return;
 
         const allEntities = [gameState.player, ...mercenaryManager.mercenaries, ...monsterManager.monsters];
         gameState.player.applyRegen();
         effectManager.update(allEntities); // EffectManager 업데이트 호출
         turnManager.update(allEntities); // 턴 매니저 업데이트
+        itemManager.update();
         eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update Start ---' });
         const player = gameState.player;
         if (player.attackCooldown > 0) player.attackCooldown--;

--- a/src/managers/itemManager.js
+++ b/src/managers/itemManager.js
@@ -16,6 +16,14 @@ export class ItemManager {
         }
     }
 
+    update() {
+        for (const item of this.items) {
+            if (typeof item.update === 'function') {
+                item.update();
+            }
+        }
+    }
+
     render(ctx) {
         for (const item of this.items) {
             item.render(ctx);


### PR DESCRIPTION
## Summary
- animate item bobbing with new update method in `Item`
- allow ItemManager to update all managed items
- drive item animations from the game loop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685407e7eb2c8327848ba1097ec47dbb