### PR TITLE
Add corpse drop on monster death

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -54,6 +54,7 @@ export class Game {
         this.loader.loadImage('ice-ball', 'assets/images/ice-ball-effect.png');
         this.loader.loadImage('strike-effect', 'assets/images/strike-effect.png');
         this.loader.loadImage('healing-effect', 'assets/images/healing-effect.png');
+        this.loader.loadImage('corpse', 'assets/images/corpse.png');
 
         this.loader.onReady(assets => this.init(assets));
     }
@@ -408,6 +409,21 @@ export class Game {
                     eventManager.publish('exp_gained', { player: attacker, exp: sharedExp });
                     eventManager.publish('exp_gained', { player: gameState.player, exp: sharedExp });
                 }
+            }
+
+            // 몬스터 시체 생성
+            if (victim.unitType === 'monster' && assets.corpse) {
+                const corpse = new Item(
+                    victim.x,
+                    victim.y,
+                    this.mapManager.tileSize,
+                    'corpse',
+                    assets.corpse
+                );
+                corpse.bobbingSpeed = 0;
+                corpse.bobbingAmount = 0;
+                corpse.baseY = victim.y;
+                this.itemManager.addItem(corpse);
             }
         });
 

--- a/tests/corpseSpawn.test.js
+++ b/tests/corpseSpawn.test.js
@@ -1,0 +1,30 @@
+import { EventManager } from '../src/managers/eventManager.js';
+import { ItemManager } from '../src/managers/itemManager.js';
+import { Item } from '../src/entities.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('Corpse', () => {
+  test('몬스터 사망 시 시체가 생성된다', () => {
+    const eventManager = new EventManager();
+    const itemManager = new ItemManager();
+    const assets = { corpse: {} };
+    const tileSize = 32;
+
+    eventManager.subscribe('entity_death', (data) => {
+      const { victim } = data;
+      const corpse = new Item(victim.x, victim.y, tileSize, 'corpse', assets.corpse);
+      corpse.bobbingSpeed = 0;
+      corpse.bobbingAmount = 0;
+      corpse.baseY = victim.y;
+      itemManager.addItem(corpse);
+    });
+
+    const victim = { x: 10, y: 20, unitType: 'monster' };
+    eventManager.publish('entity_death', { attacker: {}, victim });
+
+    assert.strictEqual(itemManager.items.length, 1, '아이템이 추가되지 않음');
+    assert.strictEqual(itemManager.items[0].name, 'corpse', '추가된 아이템이 시체가 아님');
+    assert.strictEqual(itemManager.items[0].x, 10, '시체 위치가 올바르지 않음');
+    assert.strictEqual(itemManager.items[0].y, 20, '시체 위치가 올바르지 않음');
+  });
+});


### PR DESCRIPTION
## Summary
- load `corpse.png` asset
- when a monster dies, create an Item with corpse sprite at the death location
- test corpse creation on death

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854306edb748327bf6e50b2d21ad790