### PR TITLE
Fix monster drop and show info panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
 - 스킬과 아이템의 `tags` 배열이 비어 있지 않은지 확인합니다.
 새로운 데이터가 추가되면 이 파일에 검증 항목을 계속 추가하세요.
 
+드랍 테이블(`LOOT_DROP_TABLE`)은 `src/data/tables.js`에서 관리합니다. 몬스터별로
+다른 드랍 구성을 만들고 싶다면 `getMonsterLootTable` 함수를 수정하세요.
+
 ## 개발 방식
 이 프로젝트는 하루 단위의 "Content-First / Smoke-Test-Later" 흐름으로 개발됩니다.
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <div id="top-menu-bar" class="ui-frame">
         <button class="menu-btn" data-panel-id="inventory">인벤토리</button>
         <button class="menu-btn" data-panel-id="mercenary-panel">용병 부대</button>
+        <button class="menu-btn" data-panel-id="character-sheet-panel">플레이어 정보</button>
     </div>
     <div id="canvas-container">
         <canvas id="map-base-canvas" class="game-layer"></canvas>
@@ -181,6 +182,22 @@
         <button class="close-btn" data-panel-id="mercenary-panel">X</button>
         <h2>🗡️ 용병 부대</h2>
         <div id="mercenary-list"></div>
+    </div>
+
+    <!-- 캐릭터 스탯을 표시하는 패널 -->
+    <div id="character-sheet-panel" class="modal-panel ui-frame hidden">
+        <button class="close-btn" data-panel-id="character-sheet-panel">X</button>
+        <h2 id="sheet-character-name">캐릭터</h2>
+        <div class="stats-content-box">
+            <div id="sheet-equipment" class="equipment-slots">
+                <div class="equip-slot" data-slot="weapon"><span>무기</span></div>
+                <div class="equip-slot" data-slot="armor"><span>방어구</span></div>
+                <div class="equip-slot" data-slot="accessory1"><span>악세서리1</span></div>
+                <div class="equip-slot" data-slot="accessory2"><span>악세서리2</span></div>
+            </div>
+            <div id="sheet-inventory"></div>
+            <div id="stat-page-1" class="stat-page"></div>
+        </div>
     </div>
 
 

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -42,4 +42,28 @@ export const ITEMS = {
         imageKey: 'leather_armor',
         stats: { maxHp: 5 },
     },
+
+    // 기본 소모품 및 화폐
+    potion: {
+        name: 'potion',
+        type: 'consumable',
+        tags: ['consumable'],
+        imageKey: 'potion',
+    },
+    gold: {
+        name: 'gold',
+        type: 'currency',
+        tags: ['currency'],
+        imageKey: 'gold',
+    },
+
+    // 일반적인 검 아이템 (드랍 테이블용)
+    sword: {
+        name: '검',
+        type: 'weapon',
+        damageDice: '1d6',
+        tags: ['melee', 'sword'],
+        imageKey: 'sword',
+        stats: { attackPower: 2 },
+    },
 };

--- a/src/data/tables.js
+++ b/src/data/tables.js
@@ -7,8 +7,21 @@ export const MONSTER_SPAWN_TABLE = [
 ];
 
 // 아이템 드랍 확률 테이블 (미래를 위한 구멍)
+/**
+ * 기본 아이템 드랍 테이블입니다. monsterDeathWorkflow나 초기 장비 지급 시
+ * rollOnTable()과 함께 사용합니다. 몬스터 유형별로 세분화된 테이블을
+ * 만들고 싶다면 이 배열을 기반으로 커스텀 테이블을 반환하도록
+ * getMonsterLootTable()을 수정하세요.
+ */
 export const LOOT_DROP_TABLE = [
     { id: 'gold', weight: 70 },
     { id: 'potion', weight: 25 },
     { id: 'sword', weight: 5 },
 ];
+
+// 확장성을 위해 몬스터 타입을 매개변수로 받아 드랍 테이블을 반환하는 함수
+export function getMonsterLootTable(monsterType = '') {
+    // 현재는 모든 몬스터가 동일한 테이블을 사용하지만,
+    // 필요에 따라 switch문 등으로 monsterType에 따른 분기 가능
+    return LOOT_DROP_TABLE;
+}

--- a/src/game.js
+++ b/src/game.js
@@ -24,7 +24,7 @@ import { TurnManager } from './managers/turnManager.js';
 import { SKILLS } from './data/skills.js';
 import { Item } from './entities.js';
 import { rollOnTable } from './utils/random.js';
-import { LOOT_DROP_TABLE } from './data/tables.js';
+import { getMonsterLootTable } from './data/tables.js';
 
 export class Game {
     constructor() {
@@ -224,7 +224,7 @@ export class Game {
                 monster.inventory = [];
                 const itemCount = Math.floor(Math.random() * 3) + 1;
                 for (let j = 0; j < itemCount; j++) {
-                    const id = rollOnTable(LOOT_DROP_TABLE);
+                    const id = rollOnTable(getMonsterLootTable());
                     const item = this.itemFactory.create(
                         id,
                         monster.x,
@@ -494,7 +494,7 @@ export class Game {
         });
 
         eventManager.subscribe('drop_loot', (data) => {
-            const lootTable = LOOT_DROP_TABLE;
+            const lootTable = getMonsterLootTable(data.monsterType);
             const droppedId = rollOnTable(lootTable);
             if (!droppedId) return;
 


### PR DESCRIPTION
## Summary
- add character-sheet panel and button in the UI
- define potion/gold/sword items for the loot table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685441970df48327ab612c4251305632