### PR TITLE
Fix player charge AI and stack potions

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -89,6 +89,7 @@ export class MeleeAI extends AIArchetype {
                 : null;
 
             if (
+                !self.isPlayer &&
                 chargeSkill &&
                 minDistance > self.attackRange &&
                 minDistance <= chargeSkill.chargeRange &&

--- a/src/entities.js
+++ b/src/entities.js
@@ -244,6 +244,7 @@ export class Item {
     constructor(x, y, tileSize, name, image) {
         this.x = x; this.y = y; this.width = tileSize; this.height = tileSize;
         this.name = name; this.image = image;
+        this.quantity = 1;
         this.baseId = '';
         this.tags = [];
         const statsMap = new Map();
@@ -279,6 +280,7 @@ export class Item {
     getSaveState() {
         return {
             name: this.name,
+            quantity: this.quantity,
             x: this.x,
             y: this.y,
         };

--- a/src/game.js
+++ b/src/game.js
@@ -611,7 +611,11 @@ export class Game {
                     const playerChar = gameState.player;
                     playerChar.hp = Math.min(playerChar.maxHp, playerChar.hp + 5);
                     this.particleDecoratorManager.playHealingEffect(playerChar);
-                    gameState.inventory.splice(itemIndex, 1);
+                    if (item.quantity > 1) {
+                        item.quantity -= 1;
+                    } else {
+                        gameState.inventory.splice(itemIndex, 1);
+                    }
                 }
                 this.uiManager.renderInventory(gameState);
             },
@@ -735,7 +739,12 @@ export class Game {
                 gameState.gold += 10;
                 this.combatLogManager.add(`골드를 주웠습니다! 현재 골드: ${gameState.gold}`);
             } else {
-                gameState.inventory.push(itemToPick);
+                const existing = gameState.inventory.find(i => i.name === itemToPick.name);
+                if (existing) {
+                    existing.quantity += 1;
+                } else {
+                    gameState.inventory.push(itemToPick);
+                }
                 this.combatLogManager.add(`${itemToPick.name}을(를) 인벤토리에 추가했습니다.`);
             }
             this.itemManager.removeItem(itemToPick);

--- a/src/managers/managers.js
+++ b/src/managers/managers.js
@@ -257,6 +257,12 @@ export class UIManager {
             const img = document.createElement('img');
             img.src = item.image.src;
             slotDiv.appendChild(img);
+            if (item.quantity > 1) {
+                const qty = document.createElement('span');
+                qty.className = 'item-qty';
+                qty.textContent = item.quantity;
+                slotDiv.appendChild(qty);
+            }
             slotDiv.onclick = () => {
                 if (this.callbacks.onItemUse) this.callbacks.onItemUse(index);
             };
@@ -303,6 +309,12 @@ export class UIManager {
                 const img = document.createElement('img');
                 img.src = item.image.src;
                 img.alt = item.name;
+                if (item.quantity > 1) {
+                    const qty = document.createElement('span');
+                    qty.className = 'item-qty';
+                    qty.textContent = item.quantity;
+                    slot.appendChild(qty);
+                }
                 slot.onclick = () => {
                     if (this.callbacks.onItemUse) this.callbacks.onItemUse(index);
                 };
@@ -348,6 +360,7 @@ export class UIManager {
         if (current.length !== this._lastInventory.length) return true;
         for (let i = 0; i < current.length; i++) {
             if (current[i] !== this._lastInventory[i]) return true;
+            if (current[i].quantity !== this._lastInventory[i].quantity) return true;
         }
         return false;
     }
@@ -366,7 +379,11 @@ export class UIManager {
             if (this.particleDecoratorManager) {
                 this.particleDecoratorManager.playHealingEffect(player);
             }
-            gameState.inventory.splice(itemIndex, 1);
+            if (item.quantity > 1) {
+                item.quantity -= 1;
+            } else {
+                gameState.inventory.splice(itemIndex, 1);
+            }
             this.updateUI(gameState);
         }
     }

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -293,6 +293,12 @@ export class UIManager {
             const img = document.createElement('img');
             img.src = item.image.src;
             slotDiv.appendChild(img);
+            if (item.quantity > 1) {
+                const qty = document.createElement('span');
+                qty.className = 'item-qty';
+                qty.textContent = item.quantity;
+                slotDiv.appendChild(qty);
+            }
             this._attachTooltip(slotDiv, this._getItemTooltip(item));
             slotDiv.onclick = () => {
                 if (this.callbacks.onItemUse) this.callbacks.onItemUse(index);
@@ -340,6 +346,12 @@ export class UIManager {
                 const img = document.createElement('img');
                 img.src = item.image.src;
                 img.alt = item.name;
+                if (item.quantity > 1) {
+                    const qty = document.createElement('span');
+                    qty.className = 'item-qty';
+                    qty.textContent = item.quantity;
+                    slot.appendChild(qty);
+                }
                 this._attachTooltip(slot, this._getItemTooltip(item));
                 slot.onclick = () => {
                     if (this.callbacks.onItemUse) this.callbacks.onItemUse(index);
@@ -386,6 +398,7 @@ export class UIManager {
         if (current.length !== this._lastInventory.length) return true;
         for (let i = 0; i < current.length; i++) {
             if (current[i] !== this._lastInventory[i]) return true;
+            if (current[i].quantity !== this._lastInventory[i].quantity) return true;
         }
         return false;
     }
@@ -404,7 +417,11 @@ export class UIManager {
             if (this.particleDecoratorManager) {
                 this.particleDecoratorManager.playHealingEffect(player);
             }
-            gameState.inventory.splice(itemIndex, 1);
+            if (item.quantity > 1) {
+                item.quantity -= 1;
+            } else {
+                gameState.inventory.splice(itemIndex, 1);
+            }
             this.updateUI(gameState);
         }
     }

--- a/style.css
+++ b/style.css
@@ -326,6 +326,17 @@ body, html {
     height: 100%;
 }
 
+.item-qty {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    background: rgba(0,0,0,0.6);
+    color: #fff;
+    font-size: 12px;
+    padding: 0 2px;
+    border-radius: 2px;
+}
+
 .tooltip {
     position: fixed;
     color: #fff;


### PR DESCRIPTION
## Summary
- stop player AI from auto-using charge attack
- track item quantity on items
- stack picked-up potions in player's inventory
- show item counts in the inventory UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685445d9e50083279bcb5e433418088c