### PR TITLE
Add consumable inventory for non-player units

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -138,6 +138,7 @@ export class Player extends Entity {
             }
         }
     }
+
 }
 
 export class Mercenary extends Entity {
@@ -146,7 +147,8 @@ export class Mercenary extends Entity {
         this.isFriendly = true;
         this.unitType = 'human'; // 용병의 타입도 '인간'
         this.ai = new MeleeAI();
-        this.inventory = [];
+        this.consumables = [];
+        this.consumableCapacity = 4;
 
         this.stuckCounter = 0;
         this.maxStuckCount = 5;
@@ -211,6 +213,13 @@ export class Mercenary extends Entity {
             this.stuckCounter = 0;
         }
     }
+
+    addConsumable(item) {
+        if (this.consumables.length >= this.consumableCapacity) return false;
+        item.quantity = 1;
+        this.consumables.push(item);
+        return true;
+    }
 }
 
 export class Monster extends Entity {
@@ -220,7 +229,8 @@ export class Monster extends Entity {
         // 나중에 몬스터 종류에 따라 'undead', 'beast' 등으로 설정 가능
         this.unitType = 'monster';
         this.ai = new MeleeAI();
-        this.inventory = [];
+        this.consumables = [];
+        this.consumableCapacity = 4;
     }
 
     render(ctx) {
@@ -237,6 +247,13 @@ export class Monster extends Entity {
                 ctx.drawImage(weapon.image, drawX, drawY, drawW, drawH);
             }
         }
+    }
+
+    addConsumable(item) {
+        if (this.consumables.length >= this.consumableCapacity) return false;
+        item.quantity = 1;
+        this.consumables.push(item);
+        return true;
     }
 }
 

--- a/src/game.js
+++ b/src/game.js
@@ -221,7 +221,8 @@ export class Game {
                 });
                 monster.equipmentRenderManager = this.equipmentRenderManager;
                 // 몬스터 초기 장비 및 소지품 설정
-                monster.inventory = [];
+                monster.consumables = [];
+                monster.consumableCapacity = 4;
                 const itemCount = Math.floor(Math.random() * 3) + 1;
                 for (let j = 0; j < itemCount; j++) {
                     const id = rollOnTable(getMonsterLootTable());
@@ -240,7 +241,7 @@ export class Game {
                     ) {
                         this.equipmentManager.equip(monster, item, null);
                     } else {
-                        monster.inventory.push(item);
+                        monster.addConsumable(item);
                     }
                 }
                 monsters.push(monster);
@@ -431,7 +432,7 @@ export class Game {
 
             if (victim.unitType === 'monster') {
                 const dropPool = [];
-                if (victim.inventory) dropPool.push(...victim.inventory);
+                if (victim.consumables) dropPool.push(...victim.consumables);
                 if (victim.equipment) {
                     for (const slot in victim.equipment) {
                         const it = victim.equipment[slot];
@@ -620,7 +621,7 @@ export class Game {
                 this.uiManager.renderInventory(gameState);
             },
             onEquipItem: (entity, item) => {
-                const targetInventory = entity.isPlayer ? gameState.inventory : (entity.inventory || gameState.inventory);
+                const targetInventory = entity.isPlayer ? gameState.inventory : (entity.consumables || entity.inventory || gameState.inventory);
                 this.equipmentManager.equip(entity, item, targetInventory);
                 gameState.inventory = gameState.inventory.filter(i => i !== item);
                 this.uiManager.renderInventory(gameState);

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -154,7 +154,7 @@ export class UIManager {
 
         if (this.mercInventory) {
             this.mercInventory.innerHTML = '';
-            const inventory = mercenary.inventory || [];
+            const inventory = mercenary.consumables || mercenary.inventory || [];
             inventory.forEach(item => {
                 const slotDiv = document.createElement('div');
                 slotDiv.className = 'inventory-item-slot';
@@ -216,7 +216,7 @@ export class UIManager {
 
         if (this.sheetInventory) {
             this.sheetInventory.innerHTML = '';
-            const inventory = entity.inventory || [];
+            const inventory = entity.consumables || entity.inventory || [];
             inventory.forEach(item => {
                 const slotDiv = document.createElement('div');
                 slotDiv.className = 'inventory-item-slot';


### PR DESCRIPTION
## Summary
- give mercenaries and monsters a 4-slot consumable inventory
- populate monster consumables on spawn
- drop consumables on monster death
- display consumables in UI panels
- equip logic now checks for new consumable inventory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854499248148327875f4d695c684bb3