### PR TITLE
Implement item use popup effect

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -122,6 +122,7 @@ export class Game {
         // UIManager가 mercenaryManager에 접근할 수 있도록 설정
         this.uiManager.mercenaryManager = this.mercenaryManager;
         this.uiManager.particleDecoratorManager = this.particleDecoratorManager;
+        this.uiManager.vfxManager = this.vfxManager;
         this.metaAIManager = new MetaAIManager(this.eventManager);
         this.aquariumManager = new AquariumManager(
             this.eventManager,

--- a/src/managers/managers.js
+++ b/src/managers/managers.js
@@ -150,6 +150,8 @@ export class UIManager {
         this._lastInventory = [];
         this._statUpCallback = null;
         this._isInitialized = false;
+        this.particleDecoratorManager = null;
+        this.vfxManager = null;
     }
 
     init(callbacks) {
@@ -378,6 +380,9 @@ export class UIManager {
             console.log(`포션을 사용했습니다! HP +5`);
             if (this.particleDecoratorManager) {
                 this.particleDecoratorManager.playHealingEffect(player);
+            }
+            if (this.vfxManager) {
+                this.vfxManager.addItemUseEffect(player, item.image);
             }
             if (item.quantity > 1) {
                 item.quantity -= 1;

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -44,6 +44,8 @@ export class UIManager {
         this._lastInventory = [];
         this._statUpCallback = null;
         this._isInitialized = false;
+        this.particleDecoratorManager = null;
+        this.vfxManager = null;
     }
 
     init(callbacks) {
@@ -416,6 +418,9 @@ export class UIManager {
             console.log(`포션을 사용했습니다! HP +5`);
             if (this.particleDecoratorManager) {
                 this.particleDecoratorManager.playHealingEffect(player);
+            }
+            if (this.vfxManager) {
+                this.vfxManager.addItemUseEffect(player, item.image);
             }
             if (item.quantity > 1) {
                 item.quantity -= 1;


### PR DESCRIPTION
## Summary
- add `addItemUseEffect` to VFXManager to display consumable icons
- let UIManager and old managers file pass VFXManager reference
- play effect when player uses a potion
- wire up UIManager.vfxManager in game setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68544bf04f0c832797fc5b619587c6df