### PR TITLE
Add epic monster to aquarium

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -158,6 +158,20 @@ export class Game {
                 baseStats: { }
             });
         }
+        // Add a single epic monster to highlight new boss-level enemies
+        this.aquariumManager.addTestingFeature({
+            type: 'monster',
+            image: assets.epic_monster,
+            baseStats: {
+                sizeInTiles_w: 2,
+                sizeInTiles_h: 2,
+                strength: 5,
+                agility: 4,
+                endurance: 20,
+                movement: 6,
+                expValue: 100
+            }
+        });
         this.aquariumInspector.run();
 
         this.playerGroup = this.metaAIManager.createGroup('player_party', STRATEGY.AGGRESSIVE);

--- a/src/managers/managers.js
+++ b/src/managers/managers.js
@@ -27,7 +27,15 @@ export class MonsterManager {
             if (monsterType === 'epic_monster') {
                 size = { w: 2, h: 2 };
                 image = this.assets.epic_monster;
-                config = { baseStats: {} };
+                config = { baseStats: {
+                    sizeInTiles_w: 2,
+                    sizeInTiles_h: 2,
+                    strength: 5,
+                    agility: 4,
+                    endurance: 20,
+                    movement: 6,
+                    expValue: 100,
+                } };
             } else {
                 size = { w: 1, h: 1 };
                 image = this.assets.monster;


### PR DESCRIPTION
## Summary
- buff epic monster stats during spawning so it is larger and stronger
- spawn a single epic monster on the Aquarium map as a test feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545688639c8327995fedb1036c7a73