### PR TITLE
Add MBTI tooltip

### DIFF
--- a/src/data/mbti.js
+++ b/src/data/mbti.js
@@ -1,6 +1,22 @@
-export const MBTI_TYPES = [
-    'ISTJ', 'ISFJ', 'INFJ', 'INTJ',
-    'ISTP', 'ISFP', 'INFP', 'INTP',
-    'ESTP', 'ESFP', 'ENFP', 'ENTP',
-    'ESTJ', 'ESFJ', 'ENFJ', 'ENTJ'
-];
+// MBTI 유형과 간단한 설명을 매핑합니다.
+export const MBTI_INFO = {
+    ISTJ: '책임감 있고 체계적인 관리자형',
+    ISFJ: '헌신적이고 배려심 깊은 수호자형',
+    INFJ: '통찰력 있는 조언자형',
+    INTJ: '계획적이며 전략적인 전문가형',
+    ISTP: '현실적이고 분석적인 장인형',
+    ISFP: '차분하고 감성적인 예술가형',
+    INFP: '이상과 가치를 중시하는 중재자형',
+    INTP: '호기심이 많고 논리적인 사색가형',
+    ESTP: '모험을 즐기는 활동가형',
+    ESFP: '긍정적이고 사교적인 연예인형',
+    ENFP: '열정적이고 창의적인 활동가형',
+    ENTP: '독창적이고 논쟁을 즐기는 발명가형',
+    ESTJ: '현실적이고 지도력 있는 관리자형',
+    ESFJ: '사람을 중시하는 친선도모형',
+    ENFJ: '타인의 성장을 돕는 선도자형',
+    ENTJ: '결단력 있고 통솔력 있는 지도자형',
+};
+
+// 사용 편의성을 위해 배열도 함께 내보냅니다.
+export const MBTI_TYPES = Object.keys(MBTI_INFO);

--- a/src/factory.js
+++ b/src/factory.js
@@ -87,8 +87,9 @@ export class CharacterFactory {
     
     // === 아래는 다이스를 굴리는 내부 함수들 (구멍만 파기) ===
     _rollMBTI() {
-        // 테스트 일관성을 위해 기본 MBTI를 고정한다
-        return 'ISFJ';
+        // MBTI를 무작위로 선택한다
+        const idx = Math.floor(Math.random() * MBTI_TYPES.length);
+        return MBTI_TYPES[idx];
     }
     _rollRandomKey(obj) { const keys = Object.keys(obj); return keys[Math.floor(Math.random() * keys.length)]; }
     _rollStars() {

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -1,4 +1,5 @@
 import { SKILLS } from '../data/skills.js';
+import { MBTI_INFO } from '../data/mbti.js';
 
 export class UIManager {
     constructor() {
@@ -138,6 +139,15 @@ export class UIManager {
         affinityDiv.textContent = `💕 호감도: ${mercenary.affinity.toFixed(1)} / ${mercenary.maxAffinity}`;
         this.mercStatsContainer.appendChild(affinityDiv);
 
+        const mbtiDiv = document.createElement('div');
+        mbtiDiv.className = 'stat-line';
+        const mbtiSpan = document.createElement('span');
+        mbtiSpan.textContent = mercenary.properties.mbti;
+        this._attachTooltip(mbtiSpan, this._getMBTITooltip(mercenary.properties.mbti));
+        mbtiDiv.innerHTML = 'MBTI: ';
+        mbtiDiv.appendChild(mbtiSpan);
+        this.mercStatsContainer.appendChild(mbtiDiv);
+
         statsToShow.forEach(stat => {
             const statDiv = document.createElement('div');
             statDiv.className = 'stat-line';
@@ -265,6 +275,17 @@ export class UIManager {
                 aLine.className = 'stat-line';
                 aLine.innerHTML = `<span>affinity:</span> <span>${entity.affinity.toFixed(1)} / ${entity.maxAffinity}</span>`;
                 page1.appendChild(aLine);
+            }
+
+            if (entity.properties && entity.properties.mbti) {
+                const mLine = document.createElement('div');
+                mLine.className = 'stat-line';
+                const span = document.createElement('span');
+                span.textContent = entity.properties.mbti;
+                this._attachTooltip(span, this._getMBTITooltip(entity.properties.mbti));
+                mLine.innerHTML = 'MBTI: ';
+                mLine.appendChild(span);
+                page1.appendChild(mLine);
             }
         }
     }
@@ -534,6 +555,11 @@ export class UIManager {
             }
         }
         return html;
+    }
+
+    _getMBTITooltip(mbti) {
+        const info = MBTI_INFO[mbti] || '';
+        return `<strong>${mbti}</strong><br>${info}`;
     }
 
     _attachTooltip(element, html) {


### PR DESCRIPTION
## Summary
- randomize MBTI selection for all units
- store descriptions for MBTI types
- display MBTI in mercenary and monster detail panels with tooltip info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545ce20ff083279eedc70bd4f3a64e