### PR TITLE
Add trait system to characters

### DIFF
--- a/src/data/traits.js
+++ b/src/data/traits.js
@@ -1,5 +1,40 @@
+// src/data/traits.js
+// 공용 특성 목록. 일단은 용병과 몬스터가 함께 사용한다.
+
 export const TRAITS = {
-    TOUGH: { name: '강인함', description: '최대 체력이 10% 증가합니다.' },
-    QUICK: { name: '날렵함', description: '회피율이 5% 증가합니다.' },
-    // ... 나머지 특성들도 여기에 추가 ...
+    TOUGH: {
+        name: '강인함',
+        description: '기본 체력이 약간 증가합니다.',
+        stats: { endurance: 1 },
+    },
+    QUICK_REFLEXES: {
+        name: '재빠른',
+        description: '공격 속도가 소폭 증가합니다.',
+        stats: { attackSpeed: 0.1 },
+    },
+    BRAVE: {
+        name: '용감함',
+        description: '전투에서 겁을 덜 먹습니다.',
+        stats: { strength: 1 },
+    },
+    FOCUSED: {
+        name: '집중력',
+        description: '정신력이 조금 향상됩니다.',
+        stats: { focus: 1 },
+    },
+    CUNNING: {
+        name: '교활함',
+        description: '이동 속도가 약간 증가합니다.',
+        stats: { movement: 1 },
+    },
+    SAVAGE: {
+        name: '흉포함',
+        description: '공격력이 증가합니다.',
+        stats: { attackPower: 2 },
+    },
+    STOIC: {
+        name: '냉정함',
+        description: '지능이 약간 향상됩니다.',
+        stats: { intelligence: 1 },
+    },
 };

--- a/src/factory.js
+++ b/src/factory.js
@@ -26,7 +26,7 @@ export class CharacterFactory {
         if (type !== 'player') {
             faithId = this._rollRandomKey(FAITHS);
         }
-        const traits = [this._rollRandomKey(TRAITS)];
+        const traits = this._rollMultipleRandomKeys(TRAITS, 2);
         const stars = this._rollStars();
 
         // 2. 기본 스탯 설정 (직업, 몬스터 종류, 출신 보너스 등)
@@ -97,7 +97,20 @@ export class CharacterFactory {
         const idx = Math.floor(Math.random() * MBTI_TYPES.length);
         return MBTI_TYPES[idx];
     }
-    _rollRandomKey(obj) { const keys = Object.keys(obj); return keys[Math.floor(Math.random() * keys.length)]; }
+    _rollRandomKey(obj) {
+        const keys = Object.keys(obj);
+        return keys[Math.floor(Math.random() * keys.length)];
+    }
+
+    _rollMultipleRandomKeys(obj, count) {
+        const keys = Object.keys(obj);
+        const result = [];
+        while (result.length < count && keys.length) {
+            const idx = Math.floor(Math.random() * keys.length);
+            result.push(keys.splice(idx, 1)[0]);
+        }
+        return result;
+    }
     _rollStars() {
         // ... (별 갯수 랜덤 배분 로직) ...
         return { strength: 1, agility: 1, endurance: 1, focus: 1, intelligence: 1 };

--- a/src/game.js
+++ b/src/game.js
@@ -111,6 +111,9 @@ export class Game {
         );
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
+        this.traitManager = this.managers.TraitManager;
+        this.mercenaryManager.setTraitManager(this.traitManager);
+        this.monsterManager.setTraitManager(this.traitManager);
 
         // 매니저 간 의존성 연결
         this.skillManager.setEffectManager(this.effectManager);
@@ -136,7 +139,8 @@ export class Game {
             this.mapManager,
             this.factory,
             this.itemFactory,
-            this.vfxManager
+            this.vfxManager,
+            this.traitManager
         );
         this.aquariumInspector = new AquariumInspector(this.aquariumManager);
 

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -1,7 +1,8 @@
 // src/managers/aquariumManager.js
 // Manages patches and features placed on the Aquarium map
+import { TRAITS } from '../data/traits.js';
 export class AquariumManager {
-    constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory, vfxManager = null) {
+    constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory, vfxManager = null, traitManager = null) {
         this.eventManager = eventManager;
         this.monsterManager = monsterManager;
         this.itemManager = itemManager;
@@ -9,6 +10,7 @@ export class AquariumManager {
         this.charFactory = charFactory;
         this.itemFactory = itemFactory;
         this.vfxManager = vfxManager;
+        this.traitManager = traitManager;
         this.features = [];
     }
 
@@ -25,6 +27,9 @@ export class AquariumManager {
                     image: feature.image,
                     baseStats: feature.baseStats || {}
                 });
+                if (this.traitManager) {
+                    this.traitManager.applyTraits(monster, TRAITS);
+                }
                 this.monsterManager.monsters.push(monster);
             }
         } else if (feature.type === 'item') {

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -16,6 +16,7 @@ import { MotionManager } from './motionManager.js';
 import { MovementManager } from './movementManager.js';
 import { EquipmentRenderManager } from './equipmentRenderManager.js';
 import { ParticleDecoratorManager } from './particleDecoratorManager.js';
+import { TraitManager } from './traitManager.js';
 // 파일 기반 로거는 Node 환경 전용이라 기본 묶음에서 제외한다
 // import { FileLogManager } from './fileLogManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
@@ -36,4 +37,5 @@ export {
     MovementManager,
     EquipmentRenderManager,
     ParticleDecoratorManager,
+    TraitManager,
 };

--- a/src/managers/mercenaryManager.js
+++ b/src/managers/mercenaryManager.js
@@ -1,3 +1,5 @@
+import { TRAITS } from '../data/traits.js';
+
 export class MercenaryManager {
     constructor(eventManager = null, assets = null, factory = null) {
         this.eventManager = eventManager;
@@ -5,7 +7,12 @@ export class MercenaryManager {
         this.factory = factory;
         this.mercenaries = [];
         this.equipmentRenderManager = null;
+        this.traitManager = null;
         console.log("[MercenaryManager] Initialized");
+    }
+
+    setTraitManager(traitManager) {
+        this.traitManager = traitManager;
     }
 
     hireMercenary(jobId, x, y, tileSize, groupId) {
@@ -24,6 +31,9 @@ export class MercenaryManager {
         if (merc) {
             if (this.equipmentRenderManager) {
                 merc.equipmentRenderManager = this.equipmentRenderManager;
+            }
+            if (this.traitManager) {
+                this.traitManager.applyTraits(merc, TRAITS);
             }
             this.mercenaries.push(merc);
         }

--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -1,9 +1,12 @@
+import { TRAITS } from '../data/traits.js';
+
 export class MonsterManager {
     constructor(eventManager = null, assets = null, factory = null) {
         this.eventManager = eventManager;
         this.assets = assets;
         this.factory = factory;
         this.monsters = [];
+        this.traitManager = null;
         console.log("[MonsterManager] Initialized");
 
         if (this.eventManager) {
@@ -11,6 +14,10 @@ export class MonsterManager {
                 this.monsters = this.monsters.filter(m => m.id !== data.victimId);
             });
         }
+    }
+
+    setTraitManager(traitManager) {
+        this.traitManager = traitManager;
     }
 
     getMonsterAt(x, y) {

--- a/src/managers/traitManager.js
+++ b/src/managers/traitManager.js
@@ -1,0 +1,25 @@
+export class TraitManager {
+    constructor(eventManager = null, assets = null, factory = null) {
+        this.eventManager = eventManager;
+        this.assets = assets;
+        this.factory = factory;
+        console.log('[TraitManager] Initialized');
+    }
+
+    applyTraits(entity, traitData) {
+        const traits = entity?.properties?.traits;
+        if (!Array.isArray(traits)) return;
+        for (const id of traits) {
+            const data = traitData[id];
+            if (!data || !data.stats) continue;
+            for (const [stat, val] of Object.entries(data.stats)) {
+                if (entity.stats && typeof entity.stats.increaseBaseStat === 'function') {
+                    entity.stats.increaseBaseStat(stat, val);
+                }
+            }
+        }
+        if (entity.stats && typeof entity.stats.recalculate === 'function') {
+            entity.stats.recalculate();
+        }
+    }
+}

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -22,7 +22,7 @@ describe('Aquarium', () => {
         const itemManager = new ItemManager(0, monsterManager.mapManager, assets);
         const factory = new CharacterFactory(assets);
         const vfx = new VFXManager(eventManager);
-        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx);
+        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx, null);
         aquariumManager.addTestingFeature({ type:'monster', image:{} });
         const inspector = new AquariumInspector(aquariumManager);
         assert.ok(inspector.run(), 'inspection fails');
@@ -35,7 +35,7 @@ describe('Aquarium', () => {
         const itemManager = new ItemManager(0, monsterManager.mapManager, assets);
         const factory = new CharacterFactory(assets);
         const vfx = new VFXManager(eventManager);
-        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx);
+        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx, null);
         aquariumManager.addTestingFeature({ type: 'bubble' });
         assert.strictEqual(vfx.emitters.length, 1);
     });

--- a/tests/traitManager.test.js
+++ b/tests/traitManager.test.js
@@ -1,0 +1,25 @@
+import { CharacterFactory } from '../src/factory.js';
+import { TraitManager } from '../src/managers/traitManager.js';
+import { TRAITS } from '../src/data/traits.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('Trait System', () => {
+    test('new mercenary gets two traits', () => {
+        const factory = new CharacterFactory({});
+        const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'warrior', image:null });
+        assert.strictEqual(merc.properties.traits.length, 2);
+        for (const id of merc.properties.traits) {
+            assert.ok(TRAITS[id]);
+        }
+    });
+
+    test('TraitManager applies stat bonuses', () => {
+        const factory = new CharacterFactory({});
+        const monster = factory.create('monster', { x:0, y:0, tileSize:1, groupId:'g', image:null });
+        monster.properties.traits = ['TOUGH'];
+        const traitManager = new TraitManager();
+        const before = monster.stats.get('endurance');
+        traitManager.applyTraits(monster, TRAITS);
+        assert.strictEqual(monster.stats.get('endurance'), before + 1);
+    });
+});


### PR DESCRIPTION
## Summary
- define shared trait data including stat bonuses
- assign two random traits when creating units
- implement `TraitManager` for applying trait effects
- connect `TraitManager` to mercenary/monster creation and aquarium features
- expose trait manager via `Managers` index and game setup
- test trait generation and application

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854622bd808832781fc6e6ce8f7385b