### PR TITLE
Add detailed MBTI and faith tooltips

### DIFF
--- a/src/data/faiths.js
+++ b/src/data/faiths.js
@@ -2,29 +2,36 @@ export const FAITHS = {
     FIRE_GOD: {
         name: '불의 신',
         description: '공격적인 성향을 강화합니다.',
+        statBonuses: { attackPower: 2, defense: -1 },
     },
     WATER_GOD: {
         name: '물의 신',
         description: '생존력과 안정성을 강화합니다.',
+        statBonuses: { maxHp: 5, maxMp: 5 },
     },
     WIND_GOD: {
         name: '바람의 신',
         description: '회피와 이동 능력을 향상시킵니다.',
+        statBonuses: { movementSpeed: 0.2, defense: -1 },
     },
     EARTH_GOD: {
         name: '땅의 신',
         description: '방어적 성향과 체력을 높여 줍니다.',
+        statBonuses: { defense: 2, movementSpeed: -0.2 },
     },
     LIGHT_GOD: {
         name: '빛의 신',
         description: '회복 및 방어 마법에 축복을 내립니다.',
+        statBonuses: { defense: 1, maxMp: 5 },
     },
     DARK_GOD: {
         name: '어둠의 신',
         description: '공격적인 마법과 치명타를 선호합니다.',
+        statBonuses: { attackPower: 2, defense: -1 },
     },
     NONE: {
         name: '무신론',
         description: '신앙에 얽매이지 않습니다.',
+        statBonuses: {},
     },
 };

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -582,12 +582,35 @@ export class UIManager {
 
     _getMBTITooltip(mbti) {
         const info = MBTI_INFO[mbti] || '';
-        return `<strong>${mbti}</strong><br>${info}`;
+        const map = {
+            E: '버프/회복을 아군에게 집중',
+            I: '버프/회복을 자신에게 사용',
+            S: '도구와 스킬을 즉시 사용',
+            N: '도구와 스킬 사용을 아껴 둠',
+            T: '약한 적을 우선 공격',
+            F: '아군과 같은 적을 공격',
+            P: '적을 보면 돌격',
+            J: '거리를 유지하며 전투'
+        };
+        const behavior = mbti
+            .split('')
+            .map(l => map[l])
+            .filter(Boolean)
+            .join(', ');
+        return `<strong>${mbti}</strong><br>${info}` +
+               (behavior ? `<br><em>AI 경향: ${behavior}</em>` : '');
     }
 
     _getFaithTooltip(faithId) {
         const data = FAITHS[faithId] || FAITHS.NONE;
-        return `<strong>${data.name}</strong><br>${data.description}`;
+        let html = `<strong>${data.name}</strong><br>${data.description}`;
+        if (data.statBonuses) {
+            const bonusText = Object.entries(data.statBonuses)
+                .map(([k, v]) => `${k} ${v > 0 ? '+' : ''}${v}`)
+                .join(', ');
+            if (bonusText) html += `<br><em>보너스: ${bonusText}</em>`;
+        }
+        return html;
     }
 
     _attachTooltip(element, html) {


### PR DESCRIPTION
## Summary
- expand faith data with stat bonuses
- show MBTI behavior patterns in tooltip
- show faith stat bonuses in tooltip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854695ae7cc8327bb70a6b6c747e09a