### PR TITLE
Implement parasite combining

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -37,3 +37,8 @@
 - 수족관 맵에서 환경 효과를 테스트하기 위해 `bubble` 피처 타입을 추가.
 - `AquariumManager`가 `bubble` 타입을 처리하여 VFX 이미터를 배치하도록 수정.
 - `aquarium.test.js`에 거품 이미터 생성 여부 테스트 추가.
+
+## 세션 9
+- ParasiteManager에 중복 기생체 결합 기능 구현.
+- Item 클래스에 rank 속성 추가 및 저장 상태 갱신.
+- 기생체 결합 로직 테스트 추가.

--- a/src/entities.js
+++ b/src/entities.js
@@ -281,6 +281,7 @@ export class Item {
         this.baseId = '';
         this.tags = [];
         this.range = 0;
+        this.rank = 1;
         const statsMap = new Map();
         statsMap.add = function(statObj) {
             for (const key in statObj) {
@@ -315,6 +316,7 @@ export class Item {
         return {
             name: this.name,
             quantity: this.quantity,
+            rank: this.rank,
             x: this.x,
             y: this.y,
         };

--- a/src/managers/parasiteManager.js
+++ b/src/managers/parasiteManager.js
@@ -15,4 +15,15 @@ export class ParasiteManager {
     hasParasite(entity) {
         return Array.isArray(entity.consumables) && entity.consumables.some(i => i.type === 'parasite' || i.tags?.includes('parasite'));
     }
+
+    combineParasites(entity, baseId) {
+        if (!Array.isArray(entity.consumables)) return false;
+        const matches = entity.consumables.filter(i => i.baseId === baseId);
+        if (matches.length < 2) return false;
+        const target = matches[0];
+        target.rank = (target.rank || 1) + 1;
+        const idx = entity.consumables.indexOf(matches[1]);
+        if (idx !== -1) entity.consumables.splice(idx, 1);
+        return true;
+    }
 }

--- a/tests/parasite.test.js
+++ b/tests/parasite.test.js
@@ -41,4 +41,19 @@ describe('Parasite System', () => {
         merc.stats.addExp(10);
         assert.strictEqual(merc.stats.get('exp'), 8);
     });
+
+    test('combine duplicates increases rank', () => {
+        const factory = new CharacterFactory(assets);
+        const itemFactory = new ItemFactory(assets);
+        const parasiteMgr = new ParasiteManager();
+        const merc = factory.create('mercenary', { x:0,y:0,tileSize:1,groupId:'g', jobId:'warrior', image:null });
+        const p1 = itemFactory.create('parasite_leech',0,0,1);
+        const p2 = itemFactory.create('parasite_leech',0,0,1);
+        parasiteMgr.equip(merc, p1);
+        parasiteMgr.equip(merc, p2);
+        const combined = parasiteMgr.combineParasites(merc, 'parasite_leech');
+        assert.ok(combined, 'should combine');
+        assert.strictEqual(merc.consumables.length, 1);
+        assert.strictEqual(merc.consumables[0].rank, 2);
+    });
 });


### PR DESCRIPTION
## Summary
- track item rank in `Item`
- add `combineParasites` to `ParasiteManager`
- test parasite combining logic
- log the new work in codex's dev-log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68546aa294fc832793b7b4e2cfa58b1f