### PR TITLE
Add summoner mercenary hire button

### DIFF
--- a/GAMEPLAY_GUIDE.md
+++ b/GAMEPLAY_GUIDE.md
@@ -91,6 +91,11 @@ comes with one of two skill sets:
 These hymns play `auraActivateMinor` or `auraActivateMajor` sound cues when
 activated, letting you know their protective or offensive effects are in play.
 
+### Summoner Mercenaries
+
+Summoners command undead minions to fight for you. They know the **Summon Skeleton** skill
+and can control up to two minions at a time.
+
 ### Mercenary Traits
 
 *This system has been removed.* Mercenaries no longer receive random traits or related bonuses.

--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
                 <button id="hire-archer">궁수 용병 고용 (50골드)</button>
                 <button id="hire-healer">힐러 용병 고용 (50골드)</button>
                 <button id="hire-wizard">마법사 용병 고용 (50골드)</button>
+                <button id="hire-summoner">소환사 용병 고용 (50골드)</button>
                 <button id="save-game-btn">게임 저장</button>
             </div>
         </div>

--- a/src/data/jobs.js
+++ b/src/data/jobs.js
@@ -50,5 +50,19 @@ export const JOBS = {
             attackPower: 12,
         }
     },
+    summoner: {
+        name: '소환사',
+        description: '하수인을 소환해 전투를 지원하는 전문가입니다.',
+        stats: {
+            strength: 2,
+            agility: 3,
+            endurance: 3,
+            focus: 10,
+            intelligence: 9,
+            movement: 10,
+            hp: 22,
+            attackPower: 11,
+        }
+    },
 };
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -8,7 +8,7 @@ import { ITEMS } from './data/items.js';
 import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
-import { RangedAI, HealerAI, WizardAI } from './ai.js';
+import { RangedAI, HealerAI, WizardAI, SummonerAI } from './ai.js';
 import { MBTI_TYPES } from './data/mbti.js';
 
 export class CharacterFactory {
@@ -83,6 +83,10 @@ export class CharacterFactory {
                     const mageSkill = Math.random() < 0.5 ? SKILLS.fireball.id : SKILLS.iceball.id;
                     merc.skills.push(mageSkill);
                     merc.ai = new WizardAI();
+                } else if (config.jobId === 'summoner') {
+                    merc.skills.push(SKILLS.summon_skeleton.id);
+                    merc.properties.maxMinions = 2;
+                    merc.ai = new SummonerAI();
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);

--- a/src/game.js
+++ b/src/game.js
@@ -40,6 +40,7 @@ export class Game {
         this.loader.loadImage('archer', 'assets/images/archer.png');
         this.loader.loadImage('healer', 'assets/images/healer.png');
         this.loader.loadImage('wizard', 'assets/images/wizard.png');
+        this.loader.loadImage('summoner', 'assets/images/dark_mage.png');
         // 기존 호환성을 위해 기본 mercenary 키도 전사 이미지로 유지
         this.loader.loadImage('mercenary', 'assets/images/warrior.png');
         this.loader.loadImage('floor', 'assets/floor.png');
@@ -384,6 +385,29 @@ export class Game {
                     if (newMerc) {
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('log', { message: `마법사 용병을 고용했습니다.` });
+                    }
+                } else {
+                    this.eventManager.publish('log', { message: `골드가 부족합니다.` });
+                }
+            };
+        }
+
+        const summonerBtn = document.getElementById('hire-summoner');
+        if (summonerBtn) {
+            summonerBtn.onclick = () => {
+                if (this.gameState.gold >= 50) {
+                    this.gameState.gold -= 50;
+                    const newMerc = this.mercenaryManager.hireMercenary(
+                        'summoner',
+                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.y,
+                        this.mapManager.tileSize,
+                        'player_party'
+                    );
+
+                    if (newMerc) {
+                        this.playerGroup.addMember(newMerc);
+                        this.eventManager.publish('log', { message: `소환사 용병을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });

--- a/tests/microSmoke.test.js
+++ b/tests/microSmoke.test.js
@@ -8,7 +8,7 @@ import { describe, test, assert } from './helpers.js';
 describe('Integration', () => {
 
 test('간단한 게임 흐름', () => {
-    const assets = { player:{}, mercenary:{}, monster:{}, sword:{}, leather_armor:{} };
+    const assets = { player:{}, mercenary:{}, monster:{}, sword:{}, leather_armor:{}, summoner:{} };
     const mapManager = new MapManager(42);
     assert.ok(mapManager.map && mapManager.map.length > 0, '맵 생성');
 
@@ -25,6 +25,9 @@ test('간단한 게임 흐름', () => {
 
     const archer = mercManager.hireMercenary('archer', 2, 0, 1, 'player_party');
     assert.ok(archer && archer.ai, '궁수 용병 고용');
+
+    const summoner = mercManager.hireMercenary('summoner', 3, 0, 1, 'player_party');
+    assert.ok(summoner && summoner.ai, '소환사 용병 고용');
 
     const monster = factory.create('monster', { x:2, y:0, tileSize:1, groupId:'dungeon_monsters', baseStats:{ expValue:5 } });
     let expEvent = false;


### PR DESCRIPTION
## Summary
- add new summoner merc type with stats and AI
- load summoner asset and provide hire button handler
- enable summoner hire UI button
- document summoner mercenaries in the gameplay guide
- include summoner in smoke test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854e985b648832792cad7052fa2e2fb