### PR TITLE
Fix item pop effect crash

### DIFF
--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -396,7 +396,9 @@ export class VFXManager {
                 const currentX = startPos.x + (endPos.x - startPos.x) * progress;
                 const currentY = startPos.y + (endPos.y - startPos.y) * progress;
                 const arc = Math.sin(progress * Math.PI) * popHeight;
-                ctx.drawImage(item.image, currentX, currentY - arc, item.width, item.height);
+                if (item.image && item.image.width) {
+                    ctx.drawImage(item.image, currentX, currentY - arc, item.width, item.height);
+                }
             } else if (effect.type === 'item_use') {
                 const w = effect.image.width * effect.scale;
                 const h = effect.image.height * effect.scale;


### PR DESCRIPTION
## Summary
- guard item_pop drawing in VFXManager against missing images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854ec3986c48327ad1fc065c4a53c50