### PR TITLE
Add Bard mercenary and effect icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
                 <button id="hire-archer">궁수 용병 고용 (50골드)</button>
                 <button id="hire-healer">힐러 용병 고용 (50골드)</button>
                 <button id="hire-wizard">마법사 용병 고용 (50골드)</button>
+                <button id="hire-bard">음유시인 고용 (50골드)</button>
                 <button id="hire-summoner">소환사 용병 고용 (50골드)</button>
                 <button id="save-game-btn">게임 저장</button>
             </div>

--- a/src/ai.js
+++ b/src/ai.js
@@ -292,3 +292,35 @@ export class SummonerAI extends RangedAI {
         return super.decideAction(self, context);
     }
 }
+
+export class BardAI extends AIArchetype {
+    decideAction(self, context) {
+        const { player, allies, mapManager } = context;
+        const songs = [SKILLS.guardian_hymn.id, SKILLS.courage_hymn.id];
+        for (const skillId of songs) {
+            const skill = SKILLS[skillId];
+            if (
+                self.skills.includes(skillId) &&
+                self.mp >= skill.manaCost &&
+                (self.skillCooldowns[skillId] || 0) <= 0 &&
+                self.equipment.weapon && self.equipment.weapon.tags.includes('song')
+            ) {
+                const target = player; // 간단히 플레이어 중심으로 시전
+                const distance = Math.hypot(target.x - self.x, target.y - self.y);
+                if (distance <= self.attackRange) {
+                    return { type: 'skill', target, skillId };
+                }
+                return { type: 'move', target };
+            }
+        }
+
+        if (self.isFriendly && !self.isPlayer) {
+            const target = this._getWanderPosition(self, player, allies, mapManager);
+            if (Math.hypot(target.x - self.x, target.y - self.y) > self.tileSize * 0.3) {
+                return { type: 'move', target };
+            }
+        }
+
+        return { type: 'idle' };
+    }
+}

--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -86,6 +86,7 @@ export const EFFECTS = {
         duration: 300,
         shieldAmount: 10,
         tags: ['buff', 'shield'],
+        iconKey: 'guardian-hymn-effect',
     },
 
     bonus_damage: {
@@ -94,6 +95,7 @@ export const EFFECTS = {
         duration: 300,
         bonusDamage: 2,
         tags: ['buff', 'attack_up'],
+        iconKey: 'courage-hymn-effect',
     },
 
     slow: {

--- a/src/data/jobs.js
+++ b/src/data/jobs.js
@@ -64,5 +64,18 @@ export const JOBS = {
             attackPower: 11,
         }
     },
+    bard: {
+        name: '음유시인',
+        description: '연주로 아군을 지원하는 전문가입니다.',
+        stats: {
+            strength: 3,
+            agility: 6,
+            endurance: 4,
+            focus: 8,
+            movement: 10,
+            hp: 26,
+            attackPower: 10,
+        }
+    },
 };
 

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -72,7 +72,7 @@ export const SKILLS = {
         description: '아군에게 보호막을 부여합니다.',
         manaCost: 12,
         cooldown: 180,
-        tags: ['skill', 'buff', 'shield', 'song', 'support', '버프'],
+        tags: ['skill', 'buff', 'shield', 'song', 'support', '버프', '연주'],
     },
     courage_hymn: {
         id: 'courage_hymn',
@@ -80,7 +80,7 @@ export const SKILLS = {
         description: '아군의 공격력을 증가시킵니다.',
         manaCost: 12,
         cooldown: 180,
-        tags: ['skill', 'buff', 'attack_up', 'song', 'support', '버프'],
+        tags: ['skill', 'buff', 'attack_up', 'song', 'support', '버프', '연주'],
     },
     hawk_eye: {
         id: 'hawk_eye',

--- a/src/factory.js
+++ b/src/factory.js
@@ -8,7 +8,7 @@ import { ITEMS } from './data/items.js';
 import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
-import { RangedAI, HealerAI, WizardAI, SummonerAI } from './ai.js';
+import { RangedAI, HealerAI, WizardAI, SummonerAI, BardAI } from './ai.js';
 import { MBTI_TYPES } from './data/mbti.js';
 
 export class CharacterFactory {
@@ -87,6 +87,11 @@ export class CharacterFactory {
                     merc.skills.push(SKILLS.summon_skeleton.id);
                     merc.properties.maxMinions = 2;
                     merc.ai = new SummonerAI();
+                } else if (config.jobId === 'bard') {
+                    merc.skills.push(SKILLS.guardian_hymn.id);
+                    merc.skills.push(SKILLS.courage_hymn.id);
+                    merc.equipment.weapon = { tags: ['weapon', 'ranged', 'bow', 'song'] };
+                    merc.ai = new BardAI();
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);

--- a/src/game.js
+++ b/src/game.js
@@ -22,6 +22,7 @@ import { FogManager } from './managers/fogManager.js';
 import { NarrativeManager } from './managers/narrativeManager.js';
 import { TurnManager } from './managers/turnManager.js';
 import { SKILLS } from './data/skills.js';
+import { EFFECTS } from './data/effects.js';
 import { Item } from './entities.js';
 import { rollOnTable } from './utils/random.js';
 import { getMonsterLootTable } from './data/tables.js';
@@ -41,6 +42,7 @@ export class Game {
         this.loader.loadImage('healer', 'assets/images/healer.png');
         this.loader.loadImage('wizard', 'assets/images/wizard.png');
         this.loader.loadImage('summoner', 'assets/images/summoner.png');
+        this.loader.loadImage('bard', 'assets/images/bard.png');
         // 기존 호환성을 위해 기본 mercenary 키도 전사 이미지로 유지
         this.loader.loadImage('mercenary', 'assets/images/warrior.png');
         this.loader.loadImage('floor', 'assets/floor.png');
@@ -53,6 +55,8 @@ export class Game {
         this.loader.loadImage('leather_armor', 'assets/images/leatherarmor.png');
         this.loader.loadImage('plate-armor', 'assets/images/plate-armor.png');
         this.loader.loadImage('violin-bow', 'assets/images/violin-bow.png');
+        this.loader.loadImage('guardian-hymn-effect', 'assets/images/Guardian Hymn-effect.png');
+        this.loader.loadImage('courage-hymn-effect', 'assets/images/Courage Hymn-effect.png');
         this.loader.loadImage('fire-ball', 'assets/images/fire-ball.png');
         this.loader.loadImage('ice-ball', 'assets/images/ice-ball-effect.png');
         this.loader.loadImage('strike-effect', 'assets/images/strike-effect.png');
@@ -132,6 +136,7 @@ export class Game {
         this.particleDecoratorManager = new Managers.ParticleDecoratorManager();
         this.particleDecoratorManager.setManagers(this.vfxManager, this.mapManager);
         this.particleDecoratorManager.init();
+        this.effectIconManager = new Managers.EffectIconManager(this.eventManager, assets);
         // UIManager가 mercenaryManager에 접근할 수 있도록 설정
         this.uiManager.mercenaryManager = this.mercenaryManager;
         this.uiManager.particleDecoratorManager = this.particleDecoratorManager;
@@ -388,6 +393,29 @@ export class Game {
                     if (newMerc) {
                         this.playerGroup.addMember(newMerc);
                         this.eventManager.publish('log', { message: `마법사 용병을 고용했습니다.` });
+                    }
+                } else {
+                    this.eventManager.publish('log', { message: `골드가 부족합니다.` });
+                }
+            };
+        }
+
+        const bardBtn = document.getElementById('hire-bard');
+        if (bardBtn) {
+            bardBtn.onclick = () => {
+                if (this.gameState.gold >= 50) {
+                    this.gameState.gold -= 50;
+                    const newMerc = this.mercenaryManager.hireMercenary(
+                        'bard',
+                        this.gameState.player.x + this.mapManager.tileSize,
+                        this.gameState.player.y,
+                        this.mapManager.tileSize,
+                        'player_party'
+                    );
+
+                    if (newMerc) {
+                        this.playerGroup.addMember(newMerc);
+                        this.eventManager.publish('log', { message: `음유시인 용병을 고용했습니다.` });
                     }
                 } else {
                     this.eventManager.publish('log', { message: `골드가 부족합니다.` });
@@ -877,6 +905,7 @@ export class Game {
         uiManager.renderHpBars(contexts.vfx, gameState.player, monsterManager.monsters, mercenaryManager.mercenaries);
         this.projectileManager.render(contexts.vfx);
         this.vfxManager.render(contexts.vfx);
+        this.effectIconManager.render(contexts.vfx, [gameState.player, ...monsterManager.monsters, ...mercenaryManager.mercenaries], EFFECTS);
 
         // weatherManager.render(contexts.weather); // (미래 구멍)
 

--- a/src/managers/effectIconManager.js
+++ b/src/managers/effectIconManager.js
@@ -1,0 +1,55 @@
+export class EffectIconManager {
+    constructor(eventManager = null, assets = {}) {
+        this.eventManager = eventManager;
+        this.assets = assets;
+    }
+
+    setAssets(assets) {
+        this.assets = assets;
+    }
+
+    render(ctx, entities, effectsData) {
+        if (!ctx || !entities) return;
+        const size = 12;
+        entities.forEach(ent => {
+            if (!ent.effects || ent.effects.length === 0) return;
+            const buffs = [];
+            const debuffs = [];
+            ent.effects.forEach(eff => {
+                const data = effectsData[eff.id];
+                if (!data || !data.iconKey) return;
+                const img = this.assets[data.iconKey];
+                if (!img) return;
+                const tags = data.tags || [];
+                if (tags.includes('debuff') || tags.includes('status_ailment')) {
+                    debuffs.push({ img, eff });
+                } else {
+                    buffs.push({ img, eff });
+                }
+            });
+            let xTop = ent.x;
+            const yTop = ent.y - size - 2;
+            buffs.forEach((b, i) => {
+                ctx.drawImage(b.img, xTop + i * (size + 2), yTop, size, size);
+                if (b.eff.duration) {
+                    const turns = Math.ceil(b.eff.remaining / 100);
+                    ctx.fillStyle = 'white';
+                    ctx.font = '8px sans-serif';
+                    ctx.textAlign = 'center';
+                    ctx.fillText(turns, xTop + i * (size + 2) + size / 2, yTop + size - 2);
+                }
+            });
+            const yBottom = ent.y + ent.height + 2;
+            debuffs.forEach((b, i) => {
+                ctx.drawImage(b.img, ent.x + i * (size + 2), yBottom, size, size);
+                if (b.eff.duration) {
+                    const turns = Math.ceil(b.eff.remaining / 100);
+                    ctx.fillStyle = 'white';
+                    ctx.font = '8px sans-serif';
+                    ctx.textAlign = 'center';
+                    ctx.fillText(turns, ent.x + i * (size + 2) + size / 2, yBottom + size - 2);
+                }
+            });
+        });
+    }
+}

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -18,6 +18,7 @@ import { EquipmentRenderManager } from './equipmentRenderManager.js';
 import { ParticleDecoratorManager } from './particleDecoratorManager.js';
 import { TraitManager } from './traitManager.js';
 import { ParasiteManager } from './parasiteManager.js';
+import { EffectIconManager } from './effectIconManager.js';
 // 파일 기반 로거는 Node 환경 전용이라 기본 묶음에서 제외한다
 // import { FileLogManager } from './fileLogManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
@@ -40,4 +41,5 @@ export {
     ParticleDecoratorManager,
     TraitManager,
     ParasiteManager,
+    EffectIconManager,
 };


### PR DESCRIPTION
## Summary
- implement Bard job with Guardian Hymn and Courage Hymn
- show hire-bard button in UI
- load bard and hymn effect assets
- create EffectIconManager for small buff/debuff icons
- add Bard AI and factory support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854f55cc3488327a061a4265192a0fc