### PR TITLE
Implement hymn buffs and summoner minions

### DIFF
--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -73,6 +73,7 @@ export const SKILLS = {
         manaCost: 12,
         cooldown: 180,
         tags: ['skill', 'buff', 'shield', 'song', 'support', '버프', '연주'],
+        effects: { target: ['shield'] },
     },
     courage_hymn: {
         id: 'courage_hymn',
@@ -81,6 +82,7 @@ export const SKILLS = {
         manaCost: 12,
         cooldown: 180,
         tags: ['skill', 'buff', 'attack_up', 'song', 'support', '버프', '연주'],
+        effects: { target: ['bonus_damage'] },
     },
     hawk_eye: {
         id: 'hawk_eye',


### PR DESCRIPTION
## Summary
- include shield/bonus_damage effects for hymn skills
- load skeleton asset
- apply hymn effects to entire ally group with VFX
- handle summon skeleton skill by spawning a friendly monster
- support new summon via game logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854fff479888327b258beaa6e40d168