### PR TITLE
Fix summon ally management and AI update

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -101,13 +101,8 @@ class Entity {
         };
     }
 
-    update(context) {
+    update() {
         this.applyRegen();
-        if (this.ai) {
-            const action = this.ai.decideAction(this, context);
-            context.metaAIManager.executeAction(this, action, context);
-        }
-
         if (this.attackCooldown > 0) this.attackCooldown--;
         for (const skillId in this.skillCooldowns) {
             if (this.skillCooldowns[skillId] > 0) {
@@ -208,7 +203,7 @@ export class Mercenary extends Entity {
     update(context) {
         const prevX = this.x;
         const prevY = this.y;
-        super.update(context);
+        super.update();
 
         if (this.x === prevX && this.y === prevY) {
             this.stuckCounter++;

--- a/src/game.js
+++ b/src/game.js
@@ -998,7 +998,8 @@ export class Game {
         });
         monster.isFriendly = caster.isFriendly;
         monster.properties.summonedBy = caster.id;
-        this.monsterManager.monsters.push(monster);
+        // 소환수는 용병 매니저에서 관리한다
+        this.mercenaryManager.mercenaries.push(monster);
         const group = this.metaAIManager.groups[caster.groupId];
         if (group) group.addMember(monster);
     }

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -123,9 +123,16 @@ export class MetaAIManager {
             const membersSorted = [...group.members].sort((a,b) => (b.attackSpeed || 1) - (a.attackSpeed || 1));
             for (const member of membersSorted) {
                 if (member.hp <= 0) continue;
-                if (member.attackCooldown > 0) member.attackCooldown--;
-                if (typeof member.applyRegen === 'function') member.applyRegen();
 
+                // 1단계: 쿨다운 감소 등 상태 업데이트
+                if (typeof member.update === 'function') {
+                    member.update(currentContext);
+                } else {
+                    if (member.attackCooldown > 0) member.attackCooldown--;
+                    if (typeof member.applyRegen === 'function') member.applyRegen();
+                }
+
+                // 2단계: 업데이트 이후 행동 결정 및 실행
                 let action = { type: 'idle' };
                 if (group.strategy !== STRATEGY.IDLE && member.ai) {
                     action = member.ai.decideAction(member, currentContext);

--- a/src/managers/mercenaryManager.js
+++ b/src/managers/mercenaryManager.js
@@ -9,6 +9,12 @@ export class MercenaryManager {
         this.equipmentRenderManager = null;
         this.traitManager = null;
         console.log("[MercenaryManager] Initialized");
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('entity_removed', (data) => {
+                this.mercenaries = this.mercenaries.filter(m => m.id !== data.victimId);
+            });
+        }
     }
 
     setTraitManager(traitManager) {


### PR DESCRIPTION
## Summary
- add summons to mercenaryManager so summoners treat them as allies
- keep mercenary list clean when summons die
- simplify Entity.update to handle only cooldown and regen
- update Mercenary.update to call base update without context
- revise MetaAIManager.update to separate state updates from action decisions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685513e910148327a41fa6cc120a71f5