### PR TITLE
Add poison debuff and purify skill

### DIFF
--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -78,6 +78,7 @@ export const EFFECTS = {
         duration: 500, // 5턴 (100프레임당 1턴 기준)
         damagePerTurn: 2,
         tags: ['status_ailment', 'poison'],
+        iconKey: 'parasite',
     },
 
     shield: {

--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -27,6 +27,17 @@ export const SKILLS = {
         manaCost: 8,
         cooldown: 90,
         tags: ['skill', 'support', 'cleanse', 'magic', '정화', '마법'],
+        removeTags: ['status_ailment'],
+    },
+    poison_sting: {
+        id: 'poison_sting',
+        name: '맹독 침',
+        description: '대상에게 독을 부여합니다.',
+        manaCost: 5,
+        cooldown: 120,
+        damageDice: '1d6',
+        tags: ['skill', 'attack', 'melee', 'poison'],
+        effects: { target: ['poison'] },
     },
     charge_attack: {
         id: 'charge_attack',

--- a/src/entities.js
+++ b/src/entities.js
@@ -256,6 +256,9 @@ export class Monster extends Entity {
         if (this.isFriendly) this.affinity = this.maxAffinity;
         this.consumables = [];
         this.consumableCapacity = 4;
+        if (Array.isArray(config.skills)) {
+            this.skills.push(...config.skills);
+        }
     }
 
     render(ctx) {

--- a/src/factory.js
+++ b/src/factory.js
@@ -8,7 +8,7 @@ import { ITEMS } from './data/items.js';
 import { PREFIXES, SUFFIXES } from './data/affixes.js';
 import { JOBS } from './data/jobs.js';
 import { SKILLS } from './data/skills.js';
-import { RangedAI, HealerAI, WizardAI, SummonerAI, BardAI } from './ai.js';
+import { RangedAI, HealerAI, WizardAI, SummonerAI, BardAI, PurifierAI, CompositeAI } from './ai.js';
 import { MBTI_TYPES } from './data/mbti.js';
 
 export class CharacterFactory {
@@ -78,7 +78,8 @@ export class CharacterFactory {
                     merc.skills.push(SKILLS.charge_attack.id);
                 } else if (config.jobId === 'healer') {
                     merc.skills.push(SKILLS.heal.id);
-                    merc.ai = new HealerAI();
+                    merc.skills.push(SKILLS.purify.id);
+                    merc.ai = new CompositeAI(new PurifierAI(), new HealerAI());
                 } else if (config.jobId === 'wizard') {
                     const mageSkill = Math.random() < 0.5 ? SKILLS.fireball.id : SKILLS.iceball.id;
                     merc.skills.push(mageSkill);

--- a/src/game.js
+++ b/src/game.js
@@ -62,6 +62,7 @@ export class Game {
         this.loader.loadImage('ice-ball', 'assets/images/ice-ball-effect.png');
         this.loader.loadImage('strike-effect', 'assets/images/strike-effect.png');
         this.loader.loadImage('healing-effect', 'assets/images/healing-effect.png');
+        this.loader.loadImage('purify-effect', 'assets/images/purify-effect.png');
         this.loader.loadImage('corpse', 'assets/images/corpse.png');
         this.loader.loadImage('parasite', 'assets/images/parasite.png');
         this.loader.loadImage('leech', 'assets/images/parasite.png');
@@ -185,7 +186,8 @@ export class Game {
                 endurance: 20,
                 movement: 6,
                 expValue: 100
-            }
+            },
+            skills: [SKILLS.poison_sting.id]
         });
         this.aquariumInspector.run();
 

--- a/src/managers/effectManager.js
+++ b/src/managers/effectManager.js
@@ -29,6 +29,15 @@ export class EffectManager {
         this.eventManager.publish('stats_changed', { entity: target });
     }
 
+    removeEffectsByTag(target, tag) {
+        if (!target.effects || target.effects.length === 0) return;
+        const initialCount = target.effects.length;
+        target.effects = target.effects.filter(eff => !(eff.tags && eff.tags.includes(tag)));
+        if (target.effects.length < initialCount) {
+            this.eventManager.publish('stats_changed', { entity: target });
+        }
+    }
+
     // 매 프레임 모든 유닛의 효과를 업데이트
     update(entities) {
         entities.forEach(entity => {

--- a/src/managers/managers.js
+++ b/src/managers/managers.js
@@ -36,6 +36,7 @@ export class MonsterManager {
                     movement: 6,
                     expValue: 100,
                 } };
+                config.skills = [SKILLS.poison_sting.id];
             } else {
                 size = { w: 1, h: 1 };
                 image = this.assets.monster;

--- a/src/managers/skillManager.js
+++ b/src/managers/skillManager.js
@@ -16,15 +16,22 @@ export class SkillManager {
     }
 
     applySkillEffects(caster, skill, target = null) {
-        if (!skill || !skill.effects || !this.effectManager) return;
-        if (skill.effects.self) {
-            for (const eff of skill.effects.self) {
-                this.effectManager.addEffect(caster, eff);
+        if (!skill || !this.effectManager) return;
+        if (skill.effects) {
+            if (skill.effects.self) {
+                for (const eff of skill.effects.self) {
+                    this.effectManager.addEffect(caster, eff);
+                }
+            }
+            if (skill.effects.target && target) {
+                for (const eff of skill.effects.target) {
+                    this.effectManager.addEffect(target, eff);
+                }
             }
         }
-        if (skill.effects.target && target) {
-            for (const eff of skill.effects.target) {
-                this.effectManager.addEffect(target, eff);
+        if (skill.removeTags && target) {
+            for (const tag of skill.removeTags) {
+                this.effectManager.removeEffectsByTag(target, tag);
             }
         }
     }

--- a/tests/purify.test.js
+++ b/tests/purify.test.js
@@ -1,0 +1,23 @@
+import { PurifierAI, HealerAI, CompositeAI } from '../src/ai.js';
+import { CharacterFactory } from '../src/factory.js';
+import { SKILLS } from '../src/data/skills.js';
+import { describe, test, assert } from './helpers.js';
+
+const assets = { player:{}, mercenary:{} };
+
+describe('Purify', () => {
+  test('healer removes ailment from ally', () => {
+    const factory = new CharacterFactory(assets);
+    const healer = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'healer' });
+    healer.ai = new CompositeAI(new PurifierAI(), new HealerAI());
+    healer.properties.mbti = 'ISFJ';
+    healer.mp = healer.maxMp;
+    const ally = factory.create('mercenary', { x:5, y:0, tileSize:1, groupId:'g', jobId:'warrior' });
+    ally.effects.push({ id:'poison', tags:['status_ailment'], remaining:100 });
+    const context = { player:{}, allies:[healer, ally], enemies:[], mapManager:{ tileSize:1, isWallAt:() => false } };
+    const action = healer.ai.decideAction(healer, context);
+    assert.strictEqual(action.type, 'skill');
+    assert.strictEqual(action.skillId, SKILLS.purify.id);
+    assert.strictEqual(action.target, ally);
+  });
+});


### PR DESCRIPTION
## Summary
- implement poison_sting skill that inflicts poison
- give poison effect an icon
- create CompositeAI and PurifierAI for cleanse logic
- let healers use both heal and purify with CompositeAI
- add poison skill to epic monsters
- enable purify skill effects in SkillManager
- include PurifierAI test

## Testing
- `node run-tests.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6855189d75848327aa7708401277bb5d