### PR TITLE
Fix skeleton summoning and display MBTI labels

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -161,6 +161,16 @@ export class Player extends Entity {
                 ctx.drawImage(weapon.image, drawX, drawY, drawW, drawH);
             }
         }
+
+        // 머리 위에 MBTI 글자를 항상 표시하여 직관적인 개성을 드러낸다
+        if (this.properties && this.properties.mbti) {
+            ctx.save();
+            ctx.fillStyle = 'yellow';
+            ctx.font = 'bold 12px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText(this.properties.mbti, this.x + this.width / 2, this.y - 4);
+            ctx.restore();
+        }
     }
 
 }

--- a/src/game.js
+++ b/src/game.js
@@ -73,6 +73,7 @@ export class Game {
     }
 
     init(assets) {
+        this.assets = assets;
         this.layerManager = new LayerManager();
         const canvas = this.layerManager.layers.mapBase;
 

--- a/src/managers/movementManager.js
+++ b/src/managers/movementManager.js
@@ -12,6 +12,15 @@ export class MovementManager {
             return;
         }
 
+        // 목표까지 남은 거리가 이동 속도 이하라면 바로 도착 처리하여
+        // 소수점 이동으로 인한 떨림을 방지한다
+        if (distance <= entity.speed) {
+            entity.x = target.x;
+            entity.y = target.y;
+            this.stuckTimers.delete(entity.id);
+            return;
+        }
+
         // 1. 관성: 거리가 멀수록 속도 증가
         const speedBonus = Math.min(5, Math.floor(distance / this.mapManager.tileSize / 2));
         const currentSpeed = entity.speed + speedBonus;


### PR DESCRIPTION
## Summary
- store loaded assets in `Game.init`
- move mercenaries more smoothly
- show MBTI text above mercenary heads
- use stored assets when summoning skeletons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68552e66b4dc8327a48e06d99a63789d