### PR TITLE
Implement buff item usage

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -96,4 +96,12 @@ export const ITEMS = {
         tags: ['pet_food'],
         imageKey: 'potion',
     },
+    // 버프 아이템
+    strength_elixir: {
+        name: '힘의 비약',
+        type: 'consumable',
+        tags: ['consumable', 'buff_item'],
+        imageKey: 'potion',
+        effectId: 'strength_buff'
+    },
 };

--- a/src/factory.js
+++ b/src/factory.js
@@ -168,6 +168,7 @@ export class ItemFactory {
             item.cooldownRemaining = 0;
         }
         if (baseItem.healAmount) item.healAmount = baseItem.healAmount;
+        if (baseItem.effectId) item.effectId = baseItem.effectId;
 
         if (Math.random() < 0.5) this._applyAffix(item, PREFIXES, 'prefix');
         if (Math.random() < 0.5) this._applyAffix(item, SUFFIXES, 'suffix');

--- a/src/game.js
+++ b/src/game.js
@@ -119,9 +119,9 @@ export class Game {
         this.itemAIManager = new Managers.ItemAIManager(
             this.eventManager,
             this.projectileManager,
-            this.vfxManager,
-            this.effectManager
+            this.vfxManager
         );
+        this.itemAIManager.setEffectManager(this.effectManager);
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
         this.traitManager = this.managers.TraitManager;
@@ -912,6 +912,7 @@ export class Game {
             projectileManager: this.projectileManager,
             itemManager: this.itemManager,
             equipmentManager: this.equipmentManager,
+            metaAIManager,
         };
         metaAIManager.update(context);
         this.itemAIManager.update(context);


### PR DESCRIPTION
## Summary
- add `strength_elixir` consumable
- allow ItemAI to use buff items on allies or self depending on MBTI
- hook effect manager via `setEffectManager`
- inject metaAIManager into item AI context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685559b5ca548327878a0119f1632c00