### PR TITLE
Fix full cycle test with position data

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
 드랍 테이블(`LOOT_DROP_TABLE`)은 `src/data/tables.js`에서 관리합니다. 몬스터별로
 다른 드랍 구성을 만들고 싶다면 `getMonsterLootTable` 함수를 수정하세요.
 
+## 통합 테스트 가이드
+복잡한 통합 테스트에서 임시 객체를 만들 때는 실제 게임 객체와 동일하게 위치(`x`, `y`), 크기(`width`, `height`), 그리고 `tileSize` 같은 필수 속성을 포함해야 합니다. 이러한 정보가 빠지면 AI 로직이 잘못된 값을 계산하여 테스트가 멈출 수 있습니다.
+
 ## 개발 방식
 이 프로젝트는 하루 단위의 "Content-First / Smoke-Test-Later" 흐름으로 개발됩니다.
 

--- a/tests/full-cycle.integration.test.js
+++ b/tests/full-cycle.integration.test.js
@@ -19,6 +19,11 @@ describe('Full Cycle Integration Test', () => {
       id: 'player',
       isPlayer: true,
       isFriendly: true,
+      x: 0,
+      y: 0,
+      width: 32,
+      height: 32,
+      tileSize: 32,
       hp: 50,
       maxHp: 50,
       gold: 100,
@@ -32,6 +37,11 @@ describe('Full Cycle Integration Test', () => {
 
     const monster = {
       id: 'monster1',
+      x: 32,
+      y: 0,
+      width: 32,
+      height: 32,
+      tileSize: 32,
       hp: 30,
       maxHp: 30,
       expValue: 20,
@@ -41,6 +51,11 @@ describe('Full Cycle Integration Test', () => {
     const healer = {
       id: 'healer1',
       isFriendly: true,
+      x: 0,
+      y: 32,
+      width: 32,
+      height: 32,
+      tileSize: 32,
       hp: 40,
       maxHp: 40,
       mp: 30,
@@ -50,6 +65,7 @@ describe('Full Cycle Integration Test', () => {
       ai: new HealerAI(),
       properties: { mbti: 'ESFJ' },
       stats: { get: () => 0 },
+      attackRange: 192,
     };
 
     // 전투 시작 - 플레이어가 몬스터를 공격
@@ -82,6 +98,7 @@ describe('Full Cycle Integration Test', () => {
 
     // 플레이어가 몬스터를 처치
     monster.takeDamage(20);
+    assert.strictEqual(monster.hp, 0);
     const wfContext = { eventManager, victim: monster, attacker: player };
     monsterDeathWorkflow(wfContext);
 


### PR DESCRIPTION
## Summary
- include position/size info in full-cycle integration test objects
- document new guideline for integration test objects in README

## Testing
- `GROUP='Full Cycle Integration Test' npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855652485a0832794c96aa2296ef7c8