### PR TITLE
Add micro world base framework

### DIFF
--- a/src/data/weapon-skills.js
+++ b/src/data/weapon-skills.js
@@ -1,0 +1,16 @@
+export const WEAPON_SKILLS = {
+    parry: {
+        id: 'parry',
+        name: '패링',
+        description: '낮은 확률로 공격을 막아냅니다.',
+        cooldown: 30,
+        tags: ['weapon_skill', 'sword']
+    },
+    backstab: {
+        id: 'backstab',
+        name: '백스탭',
+        description: '적의 뒤에서 공격 시 치명타 피해',
+        cooldown: 20,
+        tags: ['weapon_skill', 'dagger']
+    }
+};

--- a/src/entities.js
+++ b/src/entities.js
@@ -51,6 +51,16 @@ class Entity {
         // --- 상태이상 및 버프 관련 수치 ---
         this.shield = 0;       // 보호막
         this.damageBonus = 0;  // 추가 공격력
+
+        this.proficiency = {
+            sword: { level: 1, exp: 0, expNeeded: 10 },
+            dagger: { level: 1, exp: 0, expNeeded: 10 },
+            spear: { level: 1, exp: 0, expNeeded: 10 },
+            bow: { level: 1, exp: 0, expNeeded: 10 },
+        };
+
+        this.roleAI = null;
+        this.fallbackAI = null;
     }
 
     get speed() { return this.stats.get('movementSpeed'); }
@@ -298,6 +308,7 @@ export class Item {
         };
         this.stats = statsMap;
         this.sockets = [];
+        this.weaponStats = null;
 
         // Animation properties
         this.baseY = y;

--- a/src/game.js
+++ b/src/game.js
@@ -26,6 +26,8 @@ import { EFFECTS } from './data/effects.js';
 import { Item } from './entities.js';
 import { rollOnTable } from './utils/random.js';
 import { getMonsterLootTable } from './data/tables.js';
+import { MicroEngine } from './micro/MicroEngine.js';
+import { MicroItemAIManager } from './managers/microItemAIManager.js';
 
 export class Game {
     constructor() {
@@ -122,6 +124,8 @@ export class Game {
             this.vfxManager
         );
         this.itemAIManager.setEffectManager(this.effectManager);
+        this.microItemAIManager = new Managers.MicroItemAIManager();
+        this.microEngine = new MicroEngine([], this.itemManager.items);
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
         this.traitManager = this.managers.TraitManager;
@@ -856,12 +860,13 @@ export class Game {
     }
 
     update = (deltaTime) => {
-        const { gameState, mercenaryManager, monsterManager, itemManager, mapManager, inputHandler, effectManager, turnManager, pathfindingManager, metaAIManager, eventManager, equipmentManager } = this;
+        const { gameState, mercenaryManager, monsterManager, itemManager, mapManager, inputHandler, effectManager, turnManager, metaAIManager, eventManager, equipmentManager, pathfindingManager, microEngine, microItemAIManager } = this;
         if (gameState.isPaused || gameState.isGameOver) return;
 
         const allEntities = [gameState.player, ...mercenaryManager.mercenaries, ...monsterManager.monsters, ...(this.petManager?.pets || [])];
         gameState.player.applyRegen();
         effectManager.update(allEntities); // EffectManager 업데이트 호출
+        microEngine.update();
         turnManager.update(allEntities, { eventManager, player: gameState.player, parasiteManager: this.parasiteManager }); // 턴 매니저 업데이트
         itemManager.update();
         this.petManager.update();
@@ -945,6 +950,7 @@ export class Game {
             itemManager: this.itemManager,
             equipmentManager: this.equipmentManager,
             metaAIManager,
+            microItemAIManager,
         };
         metaAIManager.update(context);
         this.itemAIManager.update(context);

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -18,6 +18,7 @@ import { EquipmentRenderManager } from './equipmentRenderManager.js';
 import { ParticleDecoratorManager } from './particleDecoratorManager.js';
 import { TraitManager } from './traitManager.js';
 import { ParasiteManager } from './parasiteManager.js';
+import { MicroItemAIManager } from './microItemAIManager.js';
 import { EffectIconManager } from './effectIconManager.js';
 import { PetManager } from './petManager.js';
 import { MetaAIManager } from './metaAIManager.js';
@@ -43,6 +44,7 @@ export {
     ParticleDecoratorManager,
     TraitManager,
     ParasiteManager,
+    MicroItemAIManager,
     PetManager,
     EffectIconManager,
     MetaAIManager,

--- a/src/managers/microItemAIManager.js
+++ b/src/managers/microItemAIManager.js
@@ -1,0 +1,5 @@
+export class MicroItemAIManager {
+    getWeaponAI(weapon) {
+        return weapon?.weaponStats?.getAI() || null;
+    }
+}

--- a/src/micro/MicroEngine.js
+++ b/src/micro/MicroEngine.js
@@ -1,0 +1,13 @@
+import { MicroTurnManager } from './MicroTurnManager.js';
+
+export class MicroEngine {
+    constructor(allEntities = [], allItems = []) {
+        this.turnManager = new MicroTurnManager();
+        this.allEntities = allEntities;
+        this.allItems = allItems;
+    }
+
+    update() {
+        this.turnManager.update(this.allItems);
+    }
+}

--- a/src/micro/MicroTurnManager.js
+++ b/src/micro/MicroTurnManager.js
@@ -1,0 +1,23 @@
+export class MicroTurnManager {
+    constructor() {
+        this.turn = 0;
+    }
+
+    update(allItems) {
+        this.turn++;
+        for (const item of allItems) {
+            if (item.weaponStats && item.weaponStats.cooldown > 0) {
+                item.weaponStats.cooldown--;
+            }
+            if (item.cooldownRemaining > 0) {
+                item.cooldownRemaining--;
+            }
+        }
+    }
+
+    recordAttack(weapon) {
+        if (weapon?.weaponStats) {
+            weapon.weaponStats.gainExp(1);
+        }
+    }
+}

--- a/src/micro/WeaponAI.js
+++ b/src/micro/WeaponAI.js
@@ -1,0 +1,25 @@
+class BaseWeaponAI {
+    decideAction(wielder, weapon, context) {
+        return { type: 'idle' };
+    }
+}
+
+export class SwordAI extends BaseWeaponAI {
+    decideAction(wielder, weapon, context) {
+        return { type: 'attack', target: context.enemies[0] };
+    }
+}
+
+export class BowAI extends BaseWeaponAI {
+    decideAction(wielder, weapon, context) {
+        if (context.enemies[0]) {
+            return { type: 'attack', target: context.enemies[0] };
+        }
+        return { type: 'idle' };
+    }
+}
+
+export class SpearAI extends BaseWeaponAI {}
+export class SaberAI extends BaseWeaponAI {}
+
+export { BaseWeaponAI };

--- a/src/micro/WeaponStatManager.js
+++ b/src/micro/WeaponStatManager.js
@@ -1,0 +1,37 @@
+import { SwordAI, BowAI, SpearAI, SaberAI } from './WeaponAI.js';
+
+export class WeaponStatManager {
+    constructor(itemId) {
+        this.level = 1;
+        this.exp = 0;
+        this.expNeeded = 10;
+        this.skills = [];
+        this.cooldown = 0;
+        this.ai = this._getAIByItemId(itemId);
+    }
+
+    gainExp(amount) {
+        this.exp += amount;
+        if (this.exp >= this.expNeeded) {
+            this.levelUp();
+        }
+    }
+
+    levelUp() {
+        this.level++;
+        this.exp = 0;
+        this.expNeeded = Math.floor(this.expNeeded * 1.5);
+    }
+
+    getAI() {
+        return this.ai;
+    }
+
+    _getAIByItemId(itemId) {
+        if (itemId.includes('sword')) return new SwordAI();
+        if (itemId.includes('bow')) return new BowAI();
+        if (itemId.includes('spear')) return new SpearAI();
+        if (itemId.includes('saber')) return new SaberAI();
+        return new SwordAI();
+    }
+}

--- a/tests/weaponProficiency.test.js
+++ b/tests/weaponProficiency.test.js
@@ -1,0 +1,22 @@
+import { describe, test, assert } from './helpers.js';
+import { ItemFactory, CharacterFactory } from '../src/factory.js';
+import { WeaponStatManager } from '../src/micro/WeaponStatManager.js';
+
+const assets = { sword:{}, player:{} };
+
+describe('Micro-World: Weapon Proficiency', () => {
+  test('무기 사용 시 숙련도 경험치가 오르고 쿨타임이 적용된다', () => {
+    const itemFactory = new ItemFactory(assets);
+    const charFactory = new CharacterFactory(assets);
+    const sword = itemFactory.create('short_sword', 0,0,1);
+    const player = charFactory.create('player', { x:0, y:0, tileSize:1, groupId:'p' });
+    player.equipment.weapon = sword;
+
+    const initialExp = sword.weaponStats.exp;
+    sword.weaponStats.gainExp(1);
+    assert.strictEqual(sword.weaponStats.exp, initialExp + 1);
+
+    sword.weaponStats.cooldown = 30;
+    assert.strictEqual(sword.weaponStats.cooldown, 30);
+  });
+});


### PR DESCRIPTION
## Summary
- create micro world system files (engine, turn manager, weapon AI and stats)
- introduce MicroItemAIManager
- extend entities with proficiency and AI slots
- initialize weapon stats when creating weapons
- use roleAI/fallbackAI priority in MetaAIManager
- integrate MicroEngine into game loop
- add weapon proficiency test
- fix AI manager backward compatibility and import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68557a48350c8327bc375d78ab39e679