### PR TITLE
Implement micro weapon manager

### DIFF
--- a/src/managers/microItemAIManager.js
+++ b/src/managers/microItemAIManager.js
@@ -1,4 +1,13 @@
 export class MicroItemAIManager {
+    constructor() {
+        console.log('[MicroItemAIManager] Initialized');
+    }
+
+    /**
+     * 무기 아이템을 받아 해당 전투 AI를 반환합니다.
+     * @param {Item} weapon - 검사할 무기 아이템
+     * @returns {BaseWeaponAI | null} - 무기에 할당된 AI 또는 null
+     */
     getWeaponAI(weapon) {
         return weapon?.weaponStats?.getAI() || null;
     }


### PR DESCRIPTION
## Summary
- expand weapon stat management to include leveling and skill unlocks
- link weapon stats to items on creation
- provide a micro manager to fetch weapon AI and remove duplicate file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855809762288327a5ac7b655b405502