### PR TITLE
Integrate micro engine with events

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -37,6 +37,9 @@ export class CombatCalculator {
 
         details.finalDamage = finalDamage;
 
+        // 공격 판정이 성공적으로 끝났음을 미시 세계에 알린다
+        this.eventManager.publish('attack_landed', { attacker, defender, skill });
+
         this.eventManager.publish('damage_calculated', { ...data, damage: finalDamage, details });
     }
 }

--- a/src/game.js
+++ b/src/game.js
@@ -125,7 +125,7 @@ export class Game {
         );
         this.itemAIManager.setEffectManager(this.effectManager);
         this.microItemAIManager = new Managers.MicroItemAIManager();
-        this.microEngine = new MicroEngine([], this.itemManager.items);
+        this.microEngine = new MicroEngine(this.eventManager, this.itemManager);
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
         this.traitManager = this.managers.TraitManager;
@@ -866,7 +866,6 @@ export class Game {
         const allEntities = [gameState.player, ...mercenaryManager.mercenaries, ...monsterManager.monsters, ...(this.petManager?.pets || [])];
         gameState.player.applyRegen();
         effectManager.update(allEntities); // EffectManager 업데이트 호출
-        microEngine.update();
         turnManager.update(allEntities, { eventManager, player: gameState.player, parasiteManager: this.parasiteManager }); // 턴 매니저 업데이트
         itemManager.update();
         this.petManager.update();
@@ -956,6 +955,8 @@ export class Game {
         this.itemAIManager.update(context);
         this.projectileManager.update();
         this.vfxManager.update();
+        // micro-world engine runs after visuals and item logic
+        this.microEngine.update();
         eventManager.publish('debug', { tag: 'Frame', message: '--- Frame Update End ---' });
     }
 

--- a/src/micro/MicroEngine.js
+++ b/src/micro/MicroEngine.js
@@ -1,13 +1,63 @@
 import { MicroTurnManager } from './MicroTurnManager.js';
 
+// src/micro/MicroEngine.js
+
+// MicroEngine handles the micro-world progression. It listens for combat events
+// and updates weapon experience and proficiency accordingly.
 export class MicroEngine {
-    constructor(allEntities = [], allItems = []) {
+    constructor(eventManager, itemManager = null) {
+        this.eventManager = eventManager;
+        this.itemManager = itemManager;
         this.turnManager = new MicroTurnManager();
-        this.allEntities = allEntities;
-        this.allItems = allItems;
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('attack_landed', data => this.handleAttackLanded(data));
+        }
+        console.log('[MicroEngine] Initialized and subscribed to events.');
+    }
+
+    handleAttackLanded(data) {
+        const { attacker } = data;
+        const weapon = attacker.equipment?.weapon;
+
+        if (weapon && weapon.weaponStats) {
+            // 1. Increase weapon experience
+            weapon.weaponStats.gainExp(1);
+
+            // 2. Increase wielder's proficiency for this weapon type
+            const weaponType = this._getProficiencyType(weapon.baseId);
+            if (weaponType && attacker.proficiency && attacker.proficiency[weaponType]) {
+                const prof = attacker.proficiency[weaponType];
+                prof.exp++;
+                if (prof.exp >= prof.expNeeded) {
+                    prof.level++;
+                    prof.exp = 0;
+                    prof.expNeeded = Math.floor(prof.expNeeded * 1.5);
+                    this.eventManager.publish('log', {
+                        message: `${attacker.constructor.name}의 ${weaponType} 숙련도가 ${prof.level}레벨이 되었습니다!`,
+                        color: 'gold'
+                    });
+                }
+            }
+        }
+    }
+
+    _getProficiencyType(itemId) {
+        if (!itemId) return null;
+        if (itemId.includes('sword')) return 'sword';
+        if (itemId.includes('dagger')) return 'dagger';
+        if (itemId.includes('saber')) return 'saber';
+        if (itemId.includes('spear')) return 'spear';
+        if (itemId.includes('violin_bow')) return 'violin_bow';
+        if (itemId.includes('bow')) return 'bow';
+        return null;
     }
 
     update() {
-        this.turnManager.update(this.allItems);
+        // Reduce item and weapon cooldowns each frame
+        if (this.itemManager) {
+            this.turnManager.update(this.itemManager.items);
+        }
+        // Additional micro-world systems can be ticked here.
     }
 }


### PR DESCRIPTION
## Summary
- hook MicroEngine to `attack_landed` to award weapon and proficiency XP
- run MicroTurnManager each frame to handle item cooldowns
- supply `itemManager` to MicroEngine from game initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685583c978208327a48aa2210348d301