### PR TITLE
Implement micro combat animations and tests

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -7,6 +7,10 @@ export const ITEMS = {
         tags: ['melee', 'sword'],
         imageKey: 'sword',
         stats: { attackPower: 2 },
+        tier: 'normal',
+        durability: 100,
+        weight: 10,
+        toughness: 5,
     },
     long_bow: {
         name: '장궁',
@@ -15,6 +19,10 @@ export const ITEMS = {
         tags: ['ranged', 'bow', 'finesse_weapon'],
         imageKey: 'bow',
         stats: { attackPower: 2, attackRange: 384 },
+        tier: 'normal',
+        durability: 80,
+        weight: 8,
+        toughness: 3,
     },
 
     violin_bow: {
@@ -24,6 +32,10 @@ export const ITEMS = {
         tags: ['ranged', 'bow', 'finesse_weapon', 'song'],
         imageKey: 'violin-bow',
         stats: { attackPower: 2, attackRange: 384 },
+        tier: 'normal',
+        durability: 70,
+        weight: 7,
+        toughness: 3,
     },
 
     plate_armor: {
@@ -32,6 +44,10 @@ export const ITEMS = {
         tags: ['armor', 'heavy_armor'],
         imageKey: 'plate-armor',
         stats: { maxHp: 10 },
+        tier: 'rare',
+        durability: 200,
+        weight: 15,
+        toughness: 12,
     },
 
     // 방어구
@@ -41,6 +57,10 @@ export const ITEMS = {
         tags: ['armor', 'light_armor'],
         imageKey: 'leather_armor',
         stats: { maxHp: 5 },
+        tier: 'normal',
+        durability: 60,
+        weight: 5,
+        toughness: 4,
     },
 
     // 기본 소모품 및 화폐
@@ -67,6 +87,10 @@ export const ITEMS = {
         tags: ['melee', 'sword'],
         imageKey: 'sword',
         stats: { attackPower: 2 },
+        tier: 'normal',
+        durability: 90,
+        weight: 9,
+        toughness: 5,
     },
 
     // Parasite samples

--- a/src/entities.js
+++ b/src/entities.js
@@ -301,6 +301,12 @@ export class Item {
         this.cooldown = 0;
         this.cooldownRemaining = 0;
         this.healAmount = 0;
+
+        // micro combat properties
+        this.tier = 'normal';
+        this.durability = 0;
+        this.weight = 0;
+        this.toughness = 0;
         const statsMap = new Map();
         statsMap.add = function(statObj) {
             for (const key in statObj) {

--- a/src/factory.js
+++ b/src/factory.js
@@ -161,6 +161,11 @@ export class ItemFactory {
         item.baseId = itemId;
         item.type = baseItem.type;
         item.tags = [...baseItem.tags];
+
+        if (baseItem.tier) item.tier = baseItem.tier;
+        if (baseItem.durability) item.durability = baseItem.durability;
+        if (baseItem.weight) item.weight = baseItem.weight;
+        if (baseItem.toughness) item.toughness = baseItem.toughness;
         if (item.type === 'weapon' || item.tags.includes('weapon')) {
             item.weaponStats = new WeaponStatManager(itemId);
         }

--- a/src/micro/MicroCombatManager.js
+++ b/src/micro/MicroCombatManager.js
@@ -1,0 +1,35 @@
+const TIER_ORDER = { normal: 1, rare: 2, unique: 3 };
+
+export class MicroCombatManager {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        console.log('[MicroCombatManager] Initialized');
+    }
+
+    resolveAttack(attacker, defender) {
+        const weapon = attacker.equipment?.weapon;
+        const armor = defender.equipment?.armor;
+        if (!weapon || !armor) return;
+
+        this._resolveSingleCombat(weapon, armor, defender);
+        this._resolveSingleCombat(armor, weapon, attacker);
+    }
+
+    _resolveSingleCombat(attackingItem, defendingItem, owner) {
+        if (!attackingItem || !defendingItem) return;
+        if (TIER_ORDER[attackingItem.tier] < TIER_ORDER[defendingItem.tier]) {
+            return;
+        }
+
+        const damage = Math.max(1, (attackingItem.weight || 0) - (defendingItem.toughness || 0));
+        defendingItem.durability -= damage;
+
+        if (defendingItem.durability <= 0) {
+            if (defendingItem.type === 'weapon') {
+                this.eventManager.publish('weapon_disarmed', { owner, weapon: defendingItem });
+            } else if (defendingItem.type === 'armor') {
+                this.eventManager.publish('armor_broken', { owner, armor: defendingItem });
+            }
+        }
+    }
+}

--- a/src/workflows.js
+++ b/src/workflows.js
@@ -25,3 +25,49 @@ export function monsterDeathWorkflow(context) {
     // 4. 사망한 몬스터를 모든 매니저에서 확실하게 제거한다.
     eventManager.publish('entity_removed', { victimId: victim.id });
 }
+
+// === 무기 무장해제 워크플로우 ===
+export function disarmWorkflow(context) {
+    const { eventManager, owner, weapon, itemManager, equipmentManager, vfxManager } = context;
+
+    equipmentManager.equip(owner, null, null);
+
+    const angle = Math.random() * Math.PI * 2;
+    const distance = 100 + Math.random() * 50;
+    const endX = owner.x + Math.cos(angle) * distance;
+    const endY = owner.y + Math.sin(angle) * distance;
+
+    weapon.x = endX;
+    weapon.y = endY;
+
+    if (vfxManager) {
+        vfxManager.addEjectAnimation(weapon, { x: owner.x, y: owner.y }, angle, distance);
+    } else {
+        itemManager.addItem(weapon);
+    }
+
+    setTimeout(() => {
+        if (itemManager) itemManager.addItem(weapon);
+    }, 350);
+
+    eventManager.publish('log', {
+        message: `💥 ${owner.constructor.name}의 ${weapon.name}(이)가 튕겨나갔습니다!`,
+        color: 'orange'
+    });
+}
+
+// === 방어구 파괴 워크플로우 ===
+export function armorBreakWorkflow(context) {
+    const { eventManager, owner, armor, equipmentManager, vfxManager } = context;
+
+    equipmentManager.equip(owner, null, null);
+
+    if (vfxManager) {
+        vfxManager.addArmorBreakAnimation(armor, owner);
+    }
+
+    eventManager.publish('log', {
+        message: `🛡️ ${owner.constructor.name}의 ${armor.name}(이)가 파괴되었습니다!`,
+        color: 'red'
+    });
+}

--- a/tests/microCombat.test.js
+++ b/tests/microCombat.test.js
@@ -1,0 +1,42 @@
+import { MicroCombatManager } from '../src/micro/MicroCombatManager.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { Item } from '../src/entities.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('Micro Combat', () => {
+  test('장비 내구도 손상과 이벤트 발생', () => {
+    const eventManager = new EventManager();
+    const microCombat = new MicroCombatManager(eventManager);
+
+    const weaponImage = {};
+    const armorImage = {};
+    const weapon = new Item(0, 0, 1, 'sword', weaponImage);
+    weapon.type = 'weapon';
+    weapon.tier = 'normal';
+    weapon.durability = 1;
+    weapon.weight = 5;
+    weapon.toughness = 1;
+
+    const armor = new Item(0, 0, 1, 'armor', armorImage);
+    armor.type = 'armor';
+    armor.tier = 'normal';
+    armor.durability = 1;
+    armor.weight = 2;
+    armor.toughness = 0;
+
+    const attacker = { equipment: { weapon } };
+    const defender = { equipment: { armor } };
+
+    let disarmed = false;
+    let broken = false;
+    eventManager.subscribe('weapon_disarmed', () => { disarmed = true; });
+    eventManager.subscribe('armor_broken', () => { broken = true; });
+
+    microCombat.resolveAttack(attacker, defender);
+
+    assert.ok(disarmed, '무기 무장해제 이벤트가 발생해야 합니다');
+    assert.ok(broken, '방어구 파괴 이벤트가 발생해야 합니다');
+    assert.strictEqual(weapon.durability, 0);
+    assert.ok(armor.durability <= 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `addEjectAnimation` and `addArmorBreakAnimation` VFX helpers
- animate disarm and armor break in workflows
- simplify vfx_request handling
- add micro combat integration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558cc13d44832796ecb9b7e260129f