### PR TITLE
Add micro combat scenario tests

### DIFF
--- a/src/managers/equipmentManager.js
+++ b/src/managers/equipmentManager.js
@@ -30,8 +30,40 @@ export class EquipmentManager {
             this.tagManager.applyWeaponTags(entity);
         }
 
-        if (this.eventManager) {
+        if (this.eventManager && item) {
             this.eventManager.publish('log', { message: `${entity.constructor.name}(이)가 ${item.name} (을)를 장착했습니다.` });
+        }
+    }
+
+    /**
+     * Remove an equipped item from the given slot.
+     *
+     * @param {Object} entity - The character losing the item.
+     * @param {string} slot - 'weapon' or 'armor'.
+     * @param {Array|null} inventory - Optional array to store the removed item.
+     */
+    unequip(entity, slot, inventory = null) {
+        if (!slot || !entity.equipment[slot]) return;
+
+        const oldItem = entity.equipment[slot];
+        if (oldItem && inventory) {
+            inventory.push(oldItem);
+        }
+
+        entity.equipment[slot] = null;
+
+        if (entity.stats && typeof entity.stats.updateEquipmentStats === 'function') {
+            entity.stats.updateEquipmentStats();
+        }
+        if (typeof entity.updateAI === 'function') {
+            entity.updateAI();
+        }
+        if (this.tagManager && slot === 'weapon' && typeof this.tagManager.applyWeaponTags === 'function') {
+            this.tagManager.applyWeaponTags(entity);
+        }
+
+        if (this.eventManager) {
+            this.eventManager.publish('log', { message: `${entity.constructor.name}(이)가 ${slot}을/를 해제했습니다.` });
         }
     }
 

--- a/src/workflows.js
+++ b/src/workflows.js
@@ -30,7 +30,9 @@ export function monsterDeathWorkflow(context) {
 export function disarmWorkflow(context) {
     const { eventManager, owner, weapon, itemManager, equipmentManager, vfxManager } = context;
 
-    equipmentManager.equip(owner, null, null);
+    if (equipmentManager && typeof equipmentManager.unequip === 'function') {
+        equipmentManager.unequip(owner, 'weapon');
+    }
 
     const angle = Math.random() * Math.PI * 2;
     const distance = 100 + Math.random() * 50;
@@ -60,7 +62,9 @@ export function disarmWorkflow(context) {
 export function armorBreakWorkflow(context) {
     const { eventManager, owner, armor, equipmentManager, vfxManager } = context;
 
-    equipmentManager.equip(owner, null, null);
+    if (equipmentManager && typeof equipmentManager.unequip === 'function') {
+        equipmentManager.unequip(owner, 'armor');
+    }
 
     if (vfxManager) {
         vfxManager.addArmorBreakAnimation(armor, owner);

--- a/tests/microCombat.test.js
+++ b/tests/microCombat.test.js
@@ -1,42 +1,107 @@
-import { MicroCombatManager } from '../src/micro/MicroCombatManager.js';
-import { EventManager } from '../src/managers/eventManager.js';
-import { Item } from '../src/entities.js';
 import { describe, test, assert } from './helpers.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { CharacterFactory, ItemFactory } from '../src/factory.js';
+import { MicroCombatManager } from '../src/micro/MicroCombatManager.js';
+import { EquipmentManager } from '../src/managers/equipmentManager.js';
+import { ItemManager } from '../src/managers/itemManager.js';
+import { disarmWorkflow, armorBreakWorkflow } from '../src/workflows.js';
 
-describe('Micro Combat', () => {
-  test('장비 내구도 손상과 이벤트 발생', () => {
-    const eventManager = new EventManager();
-    const microCombat = new MicroCombatManager(eventManager);
+describe('Micro-World Combat Scenarios', () => {
+  function setupTestEnvironment() {
+      const eventManager = new EventManager();
+      const assets = { short_sword: {}, plate_armor: {} };
+      const factory = new CharacterFactory(assets);
+      const itemFactory = new ItemFactory(assets);
+      const microCombatManager = new MicroCombatManager(eventManager);
+      const equipmentManager = new EquipmentManager(eventManager);
+      const itemManager = new ItemManager();
 
-    const weaponImage = {};
-    const armorImage = {};
-    const weapon = new Item(0, 0, 1, 'sword', weaponImage);
-    weapon.type = 'weapon';
-    weapon.tier = 'normal';
-    weapon.durability = 1;
-    weapon.weight = 5;
-    weapon.toughness = 1;
+      const attacker = factory.create('player', { x:0, y:0, tileSize:1, groupId:'g' });
+      const defender = factory.create('monster', { x:1, y:0, tileSize:1, groupId:'m' });
 
-    const armor = new Item(0, 0, 1, 'armor', armorImage);
-    armor.type = 'armor';
-    armor.tier = 'normal';
-    armor.durability = 1;
-    armor.weight = 2;
-    armor.toughness = 0;
+      const context = {
+          eventManager,
+          itemManager,
+          equipmentManager,
+          vfxManager: { addEjectAnimation: () => {}, addArmorBreakAnimation: () => {} }
+      };
 
-    const attacker = { equipment: { weapon } };
-    const defender = { equipment: { armor } };
+      return { eventManager, factory, itemFactory, microCombatManager, attacker, defender, context };
+  }
 
-    let disarmed = false;
-    let broken = false;
-    eventManager.subscribe('weapon_disarmed', () => { disarmed = true; });
-    eventManager.subscribe('armor_broken', () => { broken = true; });
+  test('방어구 파괴: 무게가 높은 무기가 강인함이 낮은 방어구를 파괴한다', () => {
+      const { eventManager, itemFactory, microCombatManager, attacker, defender, context } = setupTestEnvironment();
 
-    microCombat.resolveAttack(attacker, defender);
+      const strongSword = itemFactory.create('short_sword', 0, 0, 1);
+      strongSword.weight = 200;
 
-    assert.ok(disarmed, '무기 무장해제 이벤트가 발생해야 합니다');
-    assert.ok(broken, '방어구 파괴 이벤트가 발생해야 합니다');
-    assert.strictEqual(weapon.durability, 0);
-    assert.ok(armor.durability <= 0);
+      const weakArmor = itemFactory.create('plate_armor', 0, 0, 1);
+      weakArmor.durability = 10;
+      weakArmor.toughness = 5;
+      weakArmor.tier = 'normal';
+
+      attacker.equipment.weapon = strongSword;
+      defender.equipment.armor = weakArmor;
+
+      let armorBroken = false;
+      eventManager.subscribe('armor_broken', (data) => {
+          armorBroken = true;
+          armorBreakWorkflow({ ...context, ...data });
+      });
+
+      microCombatManager.resolveAttack(attacker, defender);
+
+      assert.ok(armorBroken, 'armor_broken 이벤트가 발생해야 합니다.');
+      assert.strictEqual(defender.equipment.armor, null, '수비자의 방어구가 해제되어야 합니다.');
+  });
+
+  test('무기 무장해제: 강인함이 높은 방어구가 내구도 낮은 무기를 튕겨낸다', () => {
+      const { eventManager, itemFactory, microCombatManager, attacker, defender, context } = setupTestEnvironment();
+
+      const weakSword = itemFactory.create('short_sword', 0, 0, 1);
+      weakSword.durability = 5;
+      weakSword.toughness = 1;
+      weakSword.tier = 'normal';
+
+      const strongArmor = itemFactory.create('plate_armor', 0, 0, 1);
+      strongArmor.weight = 100;
+      strongArmor.toughness = 20;
+
+      attacker.equipment.weapon = weakSword;
+      defender.equipment.armor = strongArmor;
+
+      let weaponDisarmed = false;
+      eventManager.subscribe('weapon_disarmed', (data) => {
+          weaponDisarmed = true;
+          disarmWorkflow({ ...context, ...data });
+      });
+
+      microCombatManager.resolveAttack(attacker, defender);
+
+      assert.ok(weaponDisarmed, 'weapon_disarmed 이벤트가 발생해야 합니다.');
+      assert.strictEqual(attacker.equipment.weapon, null, '공격자의 무기가 해제되어야 합니다.');
+  });
+  
+  test('위계 질서: 일반(normal) 등급 무기는 레어(rare) 등급 방어구를 파괴할 수 없다', () => {
+      const { eventManager, itemFactory, microCombatManager, attacker, defender } = setupTestEnvironment();
+      
+      const normalSword = itemFactory.create('short_sword', 0, 0, 1);
+      normalSword.weight = 9999;
+      normalSword.tier = 'normal';
+
+      const rareArmor = itemFactory.create('plate_armor', 0, 0, 1);
+      rareArmor.durability = 1;
+      rareArmor.tier = 'rare';
+
+      attacker.equipment.weapon = normalSword;
+      defender.equipment.armor = rareArmor;
+
+      let armorBroken = false;
+      eventManager.subscribe('armor_broken', () => { armorBroken = true; });
+
+      microCombatManager.resolveAttack(attacker, defender);
+
+      assert.strictEqual(armorBroken, false, '하위 등급 장비는 상위 등급 장비를 파괴할 수 없습니다.');
+      assert.strictEqual(rareArmor.durability, 1, '하위 등급의 공격은 상위 등급 장비에 피해를 주지 않아야 합니다.');
   });
 });


### PR DESCRIPTION
## Summary
- expand `microCombat.test.js` with detailed micro combat scenarios
- add `unequip` method to `EquipmentManager` and log when unequipping
- update workflows to use the new unequip helper for disarm and armor break
- document unequip helper in equipment manager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855941d60b88327b839f010b471d3f9