### PR TITLE
Add Estoc weapon and hit-and-run AI

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -93,6 +93,23 @@ export const ITEMS = {
         toughness: 5,
     },
 
+    estoc: {
+        name: '에스톡',
+        type: 'weapon',
+        damageDice: '1d8',
+        tags: ['melee', 'sword', 'finesse_weapon'],
+        imageKey: 'sword',
+        stats: {
+            attackPower: 3,
+            movement: 2,
+            attackSpeed: 0.2,
+        },
+        tier: 'rare',
+        durability: 120,
+        weight: 7,
+        toughness: 7,
+    },
+
     // Parasite samples
     parasite_leech: {
         name: 'Leech',

--- a/src/entities.js
+++ b/src/entities.js
@@ -30,6 +30,10 @@ class Entity {
         this.effects = []; // 적용중인 효과 목록 배열 추가
         this.unitType = 'generic'; // 기본 유닛 타입을 '일반'으로 설정
 
+        // --- AI 상태 저장용 프로퍼티 ---
+        this.aiState = null;      // 현재 AI의 상태 (예: 'retreating')
+        this.aiStateTimer = 0;    // 상태 지속 시간(프레임)
+
         // --- 생존 관련 수치 ---
         this.maxFullness = config.maxFullness ?? 100;
         this.fullness = config.fullness ?? this.maxFullness;

--- a/src/micro/MicroEngine.js
+++ b/src/micro/MicroEngine.js
@@ -45,6 +45,7 @@ export class MicroEngine {
         if (!itemId) return null;
         if (itemId.includes('sword')) return 'sword';
         if (itemId.includes('dagger')) return 'dagger';
+        if (itemId.includes('estoc')) return 'estoc';
         if (itemId.includes('saber')) return 'saber';
         if (itemId.includes('spear')) return 'spear';
         if (itemId.includes('violin_bow')) return 'violin_bow';

--- a/tests/estocAI.test.js
+++ b/tests/estocAI.test.js
@@ -1,0 +1,50 @@
+import { EstocAI } from '../src/micro/WeaponAI.js';
+import { describe, test, assert } from './helpers.js';
+
+const contextBase = { mapManager: { tileSize: 1, isWallAt: () => false } };
+
+describe('EstocAI', () => {
+    test('approach and attack', () => {
+        const ai = new EstocAI();
+        const wielder = { x: 0, y: 0, attackRange: 10 };
+        const enemy = { x: 20, y: 0 };
+
+        let action = ai.decideAction(wielder, {}, { enemies: [enemy], ...contextBase });
+        assert.strictEqual(action.type, 'move');
+        assert.strictEqual(action.target, enemy);
+
+        wielder.x = 15; // now within range
+        action = ai.decideAction(wielder, {}, { enemies: [enemy], ...contextBase });
+        assert.strictEqual(action.type, 'attack');
+        assert.strictEqual(wielder.aiState, 'retreating');
+    });
+
+    test('retreat after attack', () => {
+        const ai = new EstocAI();
+        const wielder = { x: 15, y: 0, attackRange: 10, aiState: 'retreating', aiStateTimer: 30 };
+        const enemy = { x: 20, y: 0 };
+
+        const action = ai.decideAction(wielder, {}, { enemies: [enemy], ...contextBase });
+        assert.strictEqual(action.type, 'move');
+        assert.ok(action.target.x < wielder.x);
+        assert.ok(wielder.aiStateTimer < 30);
+    });
+
+    test('re-engage after retreat', () => {
+        const ai = new EstocAI();
+        const wielder = { x: 15, y: 0, attackRange: 10, aiState: 'retreating', aiStateTimer: 2 };
+        const enemy = { x: 20, y: 0 };
+
+        ai.decideAction(wielder, {}, { enemies: [enemy], ...contextBase });
+        wielder.x = 12; // move away
+        ai.decideAction(wielder, {}, { enemies: [enemy], ...contextBase });
+        wielder.x = 9; // out of range
+        ai.decideAction(wielder, {}, { enemies: [enemy], ...contextBase });
+
+        assert.strictEqual(wielder.aiState, null);
+
+        const action = ai.decideAction(wielder, {}, { enemies: [enemy], ...contextBase });
+        assert.strictEqual(action.type, 'move');
+        assert.strictEqual(action.target, enemy);
+    });
+});


### PR DESCRIPTION
## Summary
- add Estoc weapon with mobility stats
- store AI state and timer on entities
- implement EstocAI hit-and-run behavior
- alias SaberAI to EstocAI
- map Estoc items to EstocAI and proficiency
- test EstocAI behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855a4b80d5c8327a7e036a22df4034a