### PR TITLE
Add new weapons and proficiency UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,7 +210,12 @@
                 <div class="equip-slot" data-slot="accessory2"><span>장신구2</span></div>
             </div>
             <div id="sheet-inventory"></div>
-            <div id="stat-page-1" class="stat-page"></div>
+            <div class="stat-tabs">
+                <button class="stat-tab-btn active" data-tab="1">기본 스탯</button>
+                <button class="stat-tab-btn" data-tab="2">무기 숙련도</button>
+            </div>
+            <div id="stat-page-1" class="stat-page active"></div>
+            <div id="stat-page-2" class="stat-page hidden"></div>
         </div>
     </div>
 

--- a/src/assetLoader.js
+++ b/src/assetLoader.js
@@ -28,4 +28,19 @@ export class AssetLoader {
             .then(() => callback(this.assets))
             .catch(error => console.error(error));
     }
+
+    // 신규 무기 이미지들을 한 번에 로드하는 헬퍼 메서드
+    loadWeaponImages() {
+        const weapons = [
+            ['axe', 'assets/images/axe.png'],
+            ['mace', 'assets/images/mace.png'],
+            ['staff', 'assets/images/staff.png'],
+            ['spear', 'assets/images/spear.png'],
+            ['estoc', 'assets/images/Estoc.png'],
+            ['scythe', 'assets/images/scythe.png'],
+            ['whip', 'assets/images/whip.png'],
+            ['dagger', 'assets/images/dagger.png'],
+        ];
+        weapons.forEach(([key, src]) => this.loadImage(key, src));
+    }
 }

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -109,6 +109,43 @@ export const ITEMS = {
         weight: 7,
         toughness: 7,
     },
+    // --- 신규 무기 아이템 정의 ---
+    axe: {
+        name: '도끼', type: 'weapon', damageDice: '1d10',
+        tags: ['melee', 'axe'], imageKey: 'axe', stats: { attackPower: 5 },
+        tier: 'normal', durability: 150, weight: 15, toughness: 4
+    },
+    mace: {
+        name: '메이스', type: 'weapon', damageDice: '2d6',
+        tags: ['melee', 'mace'], imageKey: 'mace', stats: { attackPower: 4 },
+        tier: 'normal', durability: 200, weight: 18, toughness: 6
+    },
+    staff: {
+        name: '지팡이', type: 'weapon', damageDice: '1d4',
+        tags: ['ranged', 'staff', 'magic_weapon'], imageKey: 'staff', stats: { intelligence: 3 },
+        tier: 'normal', durability: 70, weight: 5, toughness: 2
+    },
+    spear: {
+        name: '창', type: 'weapon', damageDice: '1d8',
+        tags: ['melee', 'spear', 'reach'], imageKey: 'spear', stats: { attackPower: 3, attackRange: 256 },
+        tier: 'normal', durability: 100, weight: 9, toughness: 5
+    },
+    scythe: {
+        name: '낫', type: 'weapon', damageDice: '1d12',
+        tags: ['melee', 'scythe', 'reach'], imageKey: 'scythe', stats: { attackPower: 6, attackRange: 224 },
+        tier: 'rare', durability: 90, weight: 11, toughness: 3
+    },
+    whip: {
+        name: '채찍', type: 'weapon', damageDice: '1d6',
+        tags: ['ranged', 'whip', 'finesse_weapon'], imageKey: 'whip', stats: { agility: 2, attackRange: 288 },
+        tier: 'normal', durability: 60, weight: 4, toughness: 1
+    },
+    dagger: {
+        name: '단검', type: 'weapon', damageDice: '1d4',
+        tags: ['melee', 'dagger', 'finesse_weapon'], imageKey: 'dagger', stats: { attackSpeed: 0.3 },
+        tier: 'normal', durability: 80, weight: 3, toughness: 2
+    },
+    // --- 여기까지 ---
 
     // Parasite samples
     parasite_leech: {

--- a/src/entities.js
+++ b/src/entities.js
@@ -70,11 +70,16 @@ class Entity {
 
         this.proficiency = {
             sword: { level: 1, exp: 0, expNeeded: 10 },
+            axe: { level: 1, exp: 0, expNeeded: 10 },
+            mace: { level: 1, exp: 0, expNeeded: 10 },
             dagger: { level: 1, exp: 0, expNeeded: 10 },
-            estoc: { level: 1, exp: 0, expNeeded: 10 },
-            spear: { level: 1, exp: 0, expNeeded: 10 },
             bow: { level: 1, exp: 0, expNeeded: 10 },
             violin_bow: { level: 1, exp: 0, expNeeded: 10 },
+            staff: { level: 1, exp: 0, expNeeded: 10 },
+            spear: { level: 1, exp: 0, expNeeded: 10 },
+            estoc: { level: 1, exp: 0, expNeeded: 10 },
+            scythe: { level: 1, exp: 0, expNeeded: 10 },
+            whip: { level: 1, exp: 0, expNeeded: 10 },
         };
     }
 

--- a/src/game.js
+++ b/src/game.js
@@ -54,6 +54,7 @@ export class Game {
         this.loader.loadImage('gold', 'assets/gold.png');
         this.loader.loadImage('potion', 'assets/potion.png');
         this.loader.loadImage('sword', 'assets/images/shortsword.png');
+        this.loader.loadWeaponImages();
         this.loader.loadImage('bow', 'assets/images/bow.png');
         this.loader.loadImage('arrow', 'assets/images/arrow.png');
         this.loader.loadImage('leather_armor', 'assets/images/leatherarmor.png');

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -1,6 +1,7 @@
 // src/managers/aquariumManager.js
 // Manages patches and features placed on the Aquarium map
 import { TRAITS } from '../data/traits.js';
+import { EquipmentManager } from './equipmentManager.js';
 export class AquariumManager {
     constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory, vfxManager = null, traitManager = null) {
         this.eventManager = eventManager;
@@ -12,6 +13,8 @@ export class AquariumManager {
         this.vfxManager = vfxManager;
         this.traitManager = traitManager;
         this.features = [];
+        this.equipmentManager = new EquipmentManager(eventManager);
+        this.allWeaponIds = ['short_sword', 'long_bow', 'estoc', 'axe', 'mace', 'staff', 'spear', 'scythe', 'whip', 'dagger', 'violin_bow'];
     }
 
     addTestingFeature(feature) {
@@ -31,6 +34,16 @@ export class AquariumManager {
                     this.traitManager.applyTraits(monster, TRAITS);
                 }
                 this.monsterManager.monsters.push(monster);
+
+                // --- 몬스터에게 무작위 무기 장착 ---
+                if (Math.random() < 0.8) {
+                    const randomWeaponId = this.allWeaponIds[Math.floor(Math.random() * this.allWeaponIds.length)];
+                    const weapon = this.itemFactory.create(randomWeaponId, 0, 0, 1);
+                    if (weapon) {
+                        this.equipmentManager.equip(monster, weapon, null);
+                    }
+                }
+                // --- 여기까지 ---
             }
         } else if (feature.type === 'item') {
             const pos = this.mapManager.getRandomFloorPosition();

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -331,17 +331,42 @@ export class UIManager {
             page1.appendChild(mLine);
         }
 
-        if (entity.properties && entity.properties.faith) {
-            const fLine2 = document.createElement('div');
-            fLine2.className = 'stat-line';
-            const span2 = document.createElement('span');
-            const fId2 = entity.properties.faith;
-            span2.textContent = FAITHS[fId2].name;
-            this._attachTooltip(span2, this._getFaithTooltip(fId2));
-            fLine2.innerHTML = 'faith: ';
-            fLine2.appendChild(span2);
-            page1.appendChild(fLine2);
+            if (entity.properties && entity.properties.faith) {
+                const fLine2 = document.createElement('div');
+                fLine2.className = 'stat-line';
+                const span2 = document.createElement('span');
+                const fId2 = entity.properties.faith;
+                span2.textContent = FAITHS[fId2].name;
+                this._attachTooltip(span2, this._getFaithTooltip(fId2));
+                fLine2.innerHTML = 'faith: ';
+                fLine2.appendChild(span2);
+                page1.appendChild(fLine2);
+            }
         }
+
+        // --- 숙련도 페이지 렌더링 ---
+        const page2 = this.characterSheetPanel.querySelector('#stat-page-2');
+        if (page2) {
+            page2.innerHTML = '<h3>무기 숙련도</h3>';
+            const proficiencyList = document.createElement('div');
+            proficiencyList.className = 'proficiency-list';
+
+            for (const weaponType in entity.proficiency) {
+                const prof = entity.proficiency[weaponType];
+                const line = document.createElement('div');
+                line.className = 'proficiency-line';
+                const expRatio = (prof.exp / prof.expNeeded) * 100;
+                line.innerHTML = `
+                    <span class="prof-name">${weaponType}</span>
+                    <span class="prof-level">Lv.${prof.level}</span>
+                    <div class="prof-exp-bar-container">
+                        <div class="prof-exp-bar-fill" style="width: ${expRatio}%"></div>
+                        <span class="prof-exp-text">${prof.exp}/${prof.expNeeded}</span>
+                    </div>
+                `;
+                proficiencyList.appendChild(line);
+            }
+            page2.appendChild(proficiencyList);
         }
     }
 

--- a/src/micro/WeaponAI.js
+++ b/src/micro/WeaponAI.js
@@ -163,4 +163,18 @@ export class EstocAI extends BaseWeaponAI {
 
 export class SaberAI extends EstocAI {}
 
+// --- 신규 무기 AI 클래스 ---
+export class AxeAI extends SwordAI {}
+export class MaceAI extends SwordAI {}
+
+// 지팡이 AI: 원거리 마법 공격
+export class StaffAI extends BowAI {
+    // TODO: 지능 기반 데미지 계산 로직과 연계 필요
+}
+
+// 낫, 채찍 AI: 창과 같은 중거리 유지 AI
+export class ScytheAI extends SpearAI {}
+export class WhipAI extends SpearAI {}
+// --- 여기까지 ---
+
 export { BaseWeaponAI };

--- a/src/micro/WeaponStatManager.js
+++ b/src/micro/WeaponStatManager.js
@@ -1,4 +1,4 @@
-import { SwordAI, DaggerAI, BowAI, SpearAI, ViolinBowAI, EstocAI } from './WeaponAI.js';
+import { SwordAI, DaggerAI, BowAI, SpearAI, ViolinBowAI, EstocAI, AxeAI, MaceAI, StaffAI, ScytheAI, WhipAI } from './WeaponAI.js';
 import { WEAPON_SKILLS } from '../data/weapon-skills.js';
 
 export class WeaponStatManager {
@@ -59,6 +59,13 @@ export class WeaponStatManager {
         }
         if (itemId.includes('spear')) return new SpearAI();
         if (itemId.includes('estoc')) return new EstocAI();
+        // --- 신규 무기 AI 연결 ---
+        if (itemId.includes('axe')) return new AxeAI();
+        if (itemId.includes('mace')) return new MaceAI();
+        if (itemId.includes('staff')) return new StaffAI();
+        if (itemId.includes('scythe')) return new ScytheAI();
+        if (itemId.includes('whip')) return new WhipAI();
+        // -----------------------
         return new SwordAI(); // 기본값은 검 AI
     }
 }

--- a/style.css
+++ b/style.css
@@ -421,3 +421,11 @@ body, html {
     padding: 5px 0;
 }
 
+/* 무기 숙련도 UI */
+.proficiency-list { display: flex; flex-direction: column; gap: 8px; }
+.proficiency-line { display: grid; grid-template-columns: 80px 50px 1fr; align-items: center; font-size: 12px; }
+.prof-name { font-weight: bold; }
+.prof-exp-bar-container { position: relative; width: 100%; height: 14px; background-color: #555; border-radius: 3px; }
+.prof-exp-bar-fill { height: 100%; background-color: #a2d2ff; border-radius: 3px; }
+.prof-exp-text { position: absolute; width: 100%; text-align: center; color: black; font-size: 10px; line-height: 14px; }
+


### PR DESCRIPTION
## Summary
- load images for new weapons
- define additional weapon items and AI behaviors
- support new weapons in WeaponStatManager
- diversify Aquarium monsters with random weapons
- display weapon proficiencies in character sheet
- moved weapon asset loading into AssetLoader

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855b938cba08327b08a07e54dba8f0c