### PR TITLE
Add speech bubble manager

### DIFF
--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -55,6 +55,7 @@
 | `saveLoadManager.js` | 게임 상태 저장과 불러오기를 처리합니다. |
 | `skillManager.js` | 스킬 사용 쿨다운과 적용 로직을 관리합니다. |
 | `soundManager.js` | 효과음 및 배경 음악 재생을 초기화합니다. |
+| `speechBubbleManager.js` | 엔티티 머리 위에 대사나 스킬명을 표시하는 말풍선을 관리합니다. |
 | `tagManager.js` | 아이템과 스킬에 부여된 태그를 조회해 AI나 다른 시스템에 전달합니다. |
 | `traitManager.js` | 유닛의 특성 부여와 스탯 변화를 관리합니다. |
 | `turnManager.js` | 턴 기반 전투 모드에서 행동 순서를 결정하도록 설계되었습니다. |

--- a/src/game.js
+++ b/src/game.js
@@ -133,6 +133,7 @@ export class Game {
         this.microEngine = new MicroEngine(this.eventManager);
         this.microCombatManager = new MicroCombatManager(this.eventManager);
         this.synergyManager = new Managers.SynergyManager(this.eventManager);
+        this.speechBubbleManager = this.managers.SpeechBubbleManager;
         this.equipmentRenderManager = this.managers.EquipmentRenderManager;
         this.mercenaryManager.equipmentRenderManager = this.equipmentRenderManager;
         this.traitManager = this.managers.TraitManager;
@@ -980,11 +981,13 @@ export class Game {
             equipmentManager: this.equipmentManager,
             metaAIManager,
             microItemAIManager,
+            speechBubbleManager: this.speechBubbleManager,
         };
         metaAIManager.update(context);
         this.itemAIManager.update(context);
         this.projectileManager.update();
         this.vfxManager.update();
+        this.speechBubbleManager.update();
         // micro-world engine runs after visuals and item logic
         const allItems = [
             ...this.gameState.inventory,
@@ -1038,6 +1041,7 @@ export class Game {
         uiManager.renderHpBars(contexts.vfx, gameState.player, monsterManager.monsters, mercenaryManager.mercenaries);
         this.projectileManager.render(contexts.vfx);
         this.vfxManager.render(contexts.vfx);
+        this.speechBubbleManager.render(contexts.vfx);
         this.effectIconManager.render(contexts.vfx, [gameState.player, ...monsterManager.monsters, ...mercenaryManager.mercenaries, ...this.petManager.pets], EFFECTS);
 
         // weatherManager.render(contexts.weather); // (미래 구멍)

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -88,6 +88,9 @@ export class MetaAIManager {
                     entity.mp -= skill.manaCost;
                     entity.skillCooldowns[action.skillId] = skill.cooldown;
                     eventManager.publish('skill_used', { caster: entity, skill, target: action.target });
+                    if (context.speechBubbleManager) {
+                        context.speechBubbleManager.addBubble(entity, skill.name);
+                    }
                     const baseCd = 60;
                     entity.attackCooldown = Math.max(1, Math.round(baseCd / (entity.attackSpeed || 1)));
                 }
@@ -117,6 +120,10 @@ export class MetaAIManager {
 
                 if (action.skillId === 'parry_stance' && context.effectManager) {
                     context.effectManager.addEffect(entity, 'parry_ready');
+                }
+
+                if (context.speechBubbleManager) {
+                    context.speechBubbleManager.addBubble(entity, skillData.name);
                 }
 
                 weapon.weaponStats.setCooldown(skillData.cooldown);

--- a/src/managers/index.js
+++ b/src/managers/index.js
@@ -23,6 +23,7 @@ import { EffectIconManager } from './effectIconManager.js';
 import { PetManager } from './petManager.js';
 import { MetaAIManager } from './metaAIManager.js';
 import { SynergyManager } from '../micro/SynergyManager.js';
+import { SpeechBubbleManager } from './speechBubbleManager.js';
 // 파일 기반 로거는 Node 환경 전용이라 기본 묶음에서 제외한다
 // import { FileLogManager } from './fileLogManager.js';
 // ... (나중에 다른 매니저가 생기면 여기에 추가)
@@ -50,4 +51,5 @@ export {
     EffectIconManager,
     MetaAIManager,
     SynergyManager,
+    SpeechBubbleManager,
 };

--- a/src/managers/speechBubbleManager.js
+++ b/src/managers/speechBubbleManager.js
@@ -1,0 +1,47 @@
+export class SpeechBubbleManager {
+    constructor(eventManager = null) {
+        this.bubbles = [];
+        this.eventManager = eventManager;
+        if (this.eventManager) {
+            this.eventManager.subscribe('entity_removed', ({ victimId }) => {
+                this.bubbles = this.bubbles.filter(b => b.entity.id !== victimId);
+            });
+        }
+    }
+
+    addBubble(entity, text, duration = 90) {
+        if (!entity || !text) return;
+        this.bubbles.push({ entity, text, life: duration });
+    }
+
+    update() {
+        for (let i = this.bubbles.length - 1; i >= 0; i--) {
+            const bubble = this.bubbles[i];
+            bubble.life--;
+            if (bubble.life <= 0 || !bubble.entity) {
+                this.bubbles.splice(i, 1);
+            }
+        }
+    }
+
+    render(ctx) {
+        if (!ctx) return;
+        ctx.save();
+        ctx.font = '12px sans-serif';
+        ctx.textBaseline = 'top';
+        this.bubbles.forEach(b => {
+            const { entity, text } = b;
+            if (!entity) return;
+            const x = entity.x + entity.width / 2;
+            const y = entity.y - 18;
+            ctx.fillStyle = 'white';
+            const textWidth = ctx.measureText(text).width + 6;
+            ctx.fillStyle = 'rgba(0,0,0,0.7)';
+            ctx.fillRect(x - textWidth / 2, y - 2, textWidth, 14);
+            ctx.fillStyle = 'white';
+            ctx.textAlign = 'center';
+            ctx.fillText(text, x, y);
+        });
+        ctx.restore();
+    }
+}


### PR DESCRIPTION
## Summary
- create `SpeechBubbleManager` to display text above entities
- trigger bubbles on skill and weapon skill usage
- register the new manager and wire into the main game loop
- remove entity bubbles when an entity is removed
- document the new manager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855c37df20c832785f1f9896b127506