### PR TITLE
Shrink talisman VFX, display buff icon

### DIFF
--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -34,6 +34,7 @@ export const EFFECTS = {
         duration: 300,
         stats: { strength: 2, agility: 2, endurance: 2, intelligence: 2 },
         tags: ['buff', 'stat_up'],
+        iconKey: 'talisman2',
     },
     // 디버프
     armor_break: {

--- a/src/managers/item-ai-manager.js
+++ b/src/managers/item-ai-manager.js
@@ -98,7 +98,7 @@ export class ItemAIManager {
         if (!item) return;
         if (item.cooldownRemaining > 0) return;
         if (this.vfxManager && item.image) {
-            this.vfxManager.addItemUseEffect(entity, item.image);
+            this.vfxManager.addItemUseEffect(entity, item.image, { scale: 0.33 });
         }
         if (item.healAmount) {
             entity.hp = Math.min(entity.maxHp, entity.hp + item.healAmount);
@@ -157,7 +157,10 @@ export class ItemAIManager {
             this.effectManager.addEffect(target, item.effectId);
         }
 
-        if (this.vfxManager) this.vfxManager.addItemUseEffect(target, item.image);
+        if (this.vfxManager) {
+            const scale = (item.type === 'artifact' || item.tags?.includes('artifact')) ? 0.33 : 1;
+            this.vfxManager.addItemUseEffect(target, item.image, { scale });
+        }
 
         if (this.projectileManager && user !== target) {
             this.projectileManager.throwItem(user, target, item);

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -183,18 +183,21 @@ export class VFXManager {
      * @param {object} entity - 아이템을 사용한 유닛
      * @param {HTMLImageElement} image - 아이템 이미지
      */
-    addItemUseEffect(entity, image) {
-        if (!image) return;
+    addItemUseEffect(entity, image, options = {}) {
+        if (!image || !entity) return;
+        const scale = options.scale || 1;
+        const startScale = (options.startScale ?? 0.5) * scale;
+        const endScale = (options.endScale ?? 1.5) * scale;
         const effect = {
             type: 'item_use',
             image,
             x: entity.x + entity.width / 2,
             y: entity.y - entity.height * 0.5,
-            duration: 30,
-            life: 30,
-            startScale: 0.5,
-            endScale: 1.5,
-            scale: 0.5,
+            duration: options.duration || 30,
+            life: options.duration || 30,
+            startScale,
+            endScale,
+            scale: startScale,
             alpha: 1.0,
         };
         this.effects.push(effect);


### PR DESCRIPTION
## Summary
- tweak `addItemUseEffect` to accept options and support scaling
- show smaller effect when artifacts are used
- give the `all_stat_buff` effect an icon so it appears above units

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855c94d77d083278148fdb2850f722a