### PR TITLE
Fix AuraManager initialization

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -107,7 +107,13 @@ export class Game {
         // VFXManager는 ItemManager와 EventManager가 모두 필요합니다.
         this.managers.VFXManager = new Managers.VFXManager(this.eventManager, this.itemManager);
 
-        const otherManagerNames = Object.keys(Managers).filter(name => name !== 'VFXManager' && name !== 'ItemManager');
+        const otherManagerNames = Object.keys(Managers).filter(
+            name =>
+                name !== 'VFXManager' &&
+                name !== 'ItemManager' &&
+                name !== 'AuraManager' &&
+                name !== 'ItemAIManager'
+        );
         for (const managerName of otherManagerNames) {
             this.managers[managerName] = new Managers[managerName](this.eventManager, assets, this.factory);
         }


### PR DESCRIPTION
## Summary
- prevent generic manager loader from instantiating `AuraManager` or `ItemAIManager`
- load these managers with proper constructor parameters later in `Game.init`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856250346e883279cd8ca84a079e9fd