### PR TITLE
Nerf early game speeds

### DIFF
--- a/src/data/jobs.js
+++ b/src/data/jobs.js
@@ -6,7 +6,8 @@ export const JOBS = {
             strength: 8,
             agility: 4,
             endurance: 6,
-            movement: 10,
+            // 초반 밸런스에 맞춰 이동 속도를 낮춘다
+            movement: 4,
             hp: 40,
             attackPower: 17,
         }
@@ -18,7 +19,7 @@ export const JOBS = {
             strength: 5,
             agility: 8,
             endurance: 4,
-            movement: 10,
+            movement: 4,
             hp: 30,
             attackPower: 15,
         }
@@ -31,7 +32,7 @@ export const JOBS = {
             agility: 5,
             endurance: 4,
             focus: 8,
-            movement: 10,
+            movement: 4,
             hp: 28,
             attackPower: 10,
         }
@@ -45,7 +46,7 @@ export const JOBS = {
             endurance: 3,
             focus: 9,
             intelligence: 8,
-            movement: 10,
+            movement: 4,
             hp: 24,
             attackPower: 12,
         }
@@ -59,7 +60,7 @@ export const JOBS = {
             endurance: 3,
             focus: 10,
             intelligence: 9,
-            movement: 10,
+            movement: 4,
             hp: 22,
             attackPower: 11,
         }
@@ -72,7 +73,7 @@ export const JOBS = {
             agility: 6,
             endurance: 4,
             focus: 8,
-            movement: 10,
+            movement: 4,
             hp: 26,
             attackPower: 10,
         }

--- a/src/game.js
+++ b/src/game.js
@@ -229,7 +229,8 @@ export class Game {
             tileSize: this.mapManager.tileSize,
             groupId: this.playerGroup.id,
             image: assets.player,
-            baseStats: { strength: 5, agility: 5, endurance: 15, movement: 10 }
+            // 초반 난이도를 맞추기 위해 이동 속도를 낮춘다
+            baseStats: { strength: 5, agility: 5, endurance: 15, movement: 4 }
         });
         player.ai = null; // disable any automatic skills for the player
         player.equipmentRenderManager = this.equipmentRenderManager;

--- a/src/stats.js
+++ b/src/stats.js
@@ -13,14 +13,16 @@ export class StatManager {
             endurance: config.endurance || 1,
             focus: config.focus || 1,
             intelligence: config.intelligence || 1,
-            movement: config.movement || 3,
+            // 초반 밸런스를 고려하여 기본 이동 속도를 낮춘다
+            movement: config.movement || 2,
             expValue: config.expValue || 0,
             sizeInTiles_w: config.sizeInTiles_w || 1,
             sizeInTiles_h: config.sizeInTiles_h || 1,
             visionRange: config.visionRange || 192 * 4,
             attackRange: config.attackRange || 192,
-            castingSpeed: config.castingSpeed || 1,
-            attackSpeed: config.attackSpeed || 1,
+            // 지나치게 빠른 전투 템포를 완화하기 위해 기본 시전/공격 속도를 하향한다
+            castingSpeed: config.castingSpeed || 0.5,
+            attackSpeed: config.attackSpeed || 0.5,
             hpRegen: config.hpRegen || 0,
             mpRegen: config.mpRegen || 0,
         };

--- a/tests/statManager.test.js
+++ b/tests/statManager.test.js
@@ -9,8 +9,8 @@ test('초기 스탯 설정', () => {
     const stats = new StatManager({}, jobConfig);
     assert.strictEqual(stats.get('strength'), 5);
     assert.strictEqual(stats.get('endurance'), 10);
-    assert.strictEqual(stats.get('castingSpeed'), 1);
-    assert.strictEqual(stats.get('attackSpeed'), 1);
+    assert.strictEqual(stats.get('castingSpeed'), 0.5);
+    assert.strictEqual(stats.get('attackSpeed'), 0.5);
 });
 
 // 파생 스탯(maxHp, attackPower)이 올바르게 계산되는가?


### PR DESCRIPTION
## Summary
- slow movement, cast, and attack speed defaults
- reduce job movement stats
- adjust player starting movement
- align tests with new default speeds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68563fa3a5048327aef1c0443f5e814e