### PR TITLE
Fix DaggerAI crash when enemy has no facing

### DIFF
--- a/src/micro/WeaponAI.js
+++ b/src/micro/WeaponAI.js
@@ -57,8 +57,10 @@ export class DaggerAI extends BaseWeaponAI {
             return { type: 'attack', target: nearest };
         }
 
-        const behindX = nearest.x - nearest.facing.x * (mapManager.tileSize * 0.8);
-        const behindY = nearest.y - nearest.facing.y * (mapManager.tileSize * 0.8);
+        const facing = nearest.facing || { x: 0, y: 0 };
+        const tileSize = mapManager?.tileSize ?? 32;
+        const behindX = nearest.x - facing.x * (tileSize * 0.8);
+        const behindY = nearest.y - facing.y * (tileSize * 0.8);
         const behindTarget = { x: behindX, y: behindY };
 
         return { type: 'move', target: behindTarget };

--- a/tests/weaponAI.test.js
+++ b/tests/weaponAI.test.js
@@ -1,4 +1,4 @@
-import { BowAI, SpearAI, SwordAI, WhipAI } from '../src/micro/WeaponAI.js';
+import { BowAI, SpearAI, SwordAI, WhipAI, DaggerAI } from '../src/micro/WeaponAI.js';
 import { describe, test, assert } from './helpers.js';
 
 const mapStub = { tileSize: 1, isWallAt: () => false };
@@ -54,5 +54,14 @@ describe('WeaponAI', () => {
     assert.strictEqual(action.type, 'weapon_skill');
     assert.strictEqual(action.skillId, 'pull');
     assert.strictEqual(action.target, weak);
+  });
+
+  test('DaggerAI moves directly to enemy when facing data missing', () => {
+    const ai = new DaggerAI();
+    const wielder = { x: 0, y: 0, attackRange: 5 };
+    const enemy = { x: 12, y: 0 }; // no facing property
+    const action = ai.decideAction(wielder, {}, { enemies: [enemy], mapManager: mapStub });
+    assert.strictEqual(action.type, 'move');
+    assert.deepStrictEqual(action.target, { x: enemy.x, y: enemy.y });
   });
 });


### PR DESCRIPTION
## Summary
- handle missing `facing` data in `DaggerAI`
- add regression test for the Dagger dagger AI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856408162d88327a92e839404913a19