### PR TITLE
Add teleport and shockwave VFX with AI updates

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -828,7 +828,7 @@ export class Game {
 
         eventManager.subscribe('vfx_request', (data) => {
             if (data.type === 'dash_trail') {
-                this.vfxManager.createDashTrail(data.from.x, data.from.y, data.to.x, data.to.y);
+                this.vfxManager.createDashTrail(data.from.x, data.from.y, data.to.x, data.to.y, data.options || {});
             } else if (data.type === 'whip_trail') {
                 if (this.vfxManager.createWhipTrail) {
                     this.vfxManager.createWhipTrail(data.from.x, data.from.y, data.to.x, data.to.y);
@@ -1070,6 +1070,8 @@ export class Game {
             projectileManager: this.projectileManager,
             itemManager: this.itemManager,
             equipmentManager: this.equipmentManager,
+            vfxManager: this.vfxManager,
+            assets: this.loader.assets,
             metaAIManager,
             microItemAIManager,
             speechBubbleManager: this.speechBubbleManager,
@@ -1124,10 +1126,10 @@ export class Game {
 
         // buffManager.renderGroundAuras(contexts.groundFx, ...); // (미래 구멍)
 
-        monsterManager.render(contexts.entity);
-        mercenaryManager.render(contexts.entity);
-        this.petManager.render(contexts.entity);
-        gameState.player.render(contexts.entity);
+        monsterManager.monsters.filter(m => !m.isHidden).forEach(m => m.render(contexts.entity));
+        mercenaryManager.mercenaries.filter(m => !m.isHidden).forEach(m => m.render(contexts.entity));
+        this.petManager.pets.filter(p => !p.isHidden).forEach(p => p.render(contexts.entity));
+        if (!gameState.player.isHidden) gameState.player.render(contexts.entity);
 
         fogManager.render(contexts.vfx, mapManager.tileSize);
         uiManager.renderHpBars(contexts.vfx, gameState.player, monsterManager.monsters, mercenaryManager.mercenaries);

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -92,6 +92,21 @@ export class MetaAIManager {
                     entity.attackCooldown = Math.max(1, Math.round(baseCd / (entity.attackSpeed || 1)));
                 }
                 break;
+            case 'backstab_teleport': {
+                const { target } = action;
+                const { mapManager, vfxManager } = context;
+                if (!target || !mapManager || !vfxManager) break;
+
+                const fromPos = { x: entity.x, y: entity.y };
+                const behindX = target.x - (target.direction * (mapManager.tileSize * 0.8));
+                const behindY = target.y;
+                const toPos = { x: behindX, y: behindY };
+
+                vfxManager.addTeleportEffect(entity, fromPos, toPos, () => {
+                    this.executeAction(entity, { type: 'attack', target }, context);
+                });
+                break;
+            }
             case 'weapon_skill': {
                 const skillData = WEAPON_SKILLS[action.skillId];
                 if (!skillData) break;
@@ -109,7 +124,9 @@ export class MetaAIManager {
                         action.target,
                         3,
                         context.enemies,
-                        context.eventManager
+                        context.eventManager,
+                        context.vfxManager,
+                        context.assets['strike-effect']
                     );
                 }
 

--- a/src/managers/motionManager.js
+++ b/src/managers/motionManager.js
@@ -8,40 +8,46 @@ export class MotionManager {
     }
 
     // dash the entity toward the target up to maxTiles tiles
-    dashTowards(entity, target, maxTiles = 8, allEnemies = [], eventManager = null) {
+    dashTowards(entity, target, maxTiles = 8, allEnemies = [], eventManager = null, vfxManager = null, strikeImage = null) {
         const tileSize = this.mapManager.tileSize;
+        const startPos = { x: entity.x, y: entity.y };
+
         const startX = Math.floor(entity.x / tileSize);
         const startY = Math.floor(entity.y / tileSize);
         const endX = Math.floor(target.x / tileSize);
         const endY = Math.floor(target.y / tileSize);
 
         const path = this.pathfindingManager.findPath(startX, startY, endX, endY, () => false);
-        if (path.length < 2) return;
+        if (path.length === 0) return;
 
         const actualMoveDistance = Math.min(maxTiles, path.length);
+        const dest = path[actualMoveDistance - 1];
+        const destX = dest.x * tileSize;
+        const destY = dest.y * tileSize;
+
+        if (vfxManager) {
+            vfxManager.createDashTrail(startPos.x, startPos.y, destX, destY, { color: 'rgba(255,255,255,0.7)', lifespan: 25 });
+        }
+
         const hitEnemies = new Set();
         for (let i = 0; i < actualMoveDistance; i++) {
             const step = path[i];
             const worldX = step.x * tileSize + tileSize / 2;
             const worldY = step.y * tileSize + tileSize / 2;
+
             const enemiesInPath = findEntitiesInRadius(worldX, worldY, tileSize, allEnemies, entity);
             for (const enemy of enemiesInPath) {
                 if (!hitEnemies.has(enemy.id)) {
                     if (eventManager) {
-                        eventManager.publish('entity_attack', {
-                            attacker: entity,
-                            defender: enemy,
-                            skill: { name: '돌진' }
-                        });
+                        eventManager.publish('entity_attack', { attacker: entity, defender: enemy, skill: { name: '돌진' } });
+                    }
+                    if (vfxManager && strikeImage) {
+                        vfxManager.addSpriteEffect(strikeImage, enemy.x + enemy.width / 2, enemy.y + enemy.height / 2, { blendMode: 'screen' });
                     }
                     hitEnemies.add(enemy.id);
                 }
             }
         }
-
-        const dest = path[actualMoveDistance - 1];
-        const destX = dest.x * tileSize;
-        const destY = dest.y * tileSize;
 
         if (!this.mapManager.isWallAt(destX, destY, entity.width, entity.height)) {
             entity.x = destX;

--- a/src/managers/projectileManager.js
+++ b/src/managers/projectileManager.js
@@ -77,7 +77,13 @@ export class ProjectileManager {
                 const weapon = proj.caster.equipment.weapon;
                 if (weapon && weapon.weaponStats?.skills.includes('sonic_arrow')) {
                     const radius = 128;
-                    const aoeTargets = findEntitiesInRadius(result.target.x, result.target.y, radius, allEntities, result.target);
+                    const impactPos = { x: result.target.x + result.target.width/2, y: result.target.y + result.target.height/2 };
+
+                    if (this.vfxManager) {
+                        this.vfxManager.addShockwave(impactPos.x, impactPos.y, { maxRadius: radius });
+                    }
+
+                    const aoeTargets = findEntitiesInRadius(impactPos.x, impactPos.y, radius, allEntities, result.target);
                     for (const aoeTarget of aoeTargets) {
                         if (aoeTarget.isFriendly !== proj.caster.isFriendly) {
                             this.eventManager.publish('log', { message: `[음파 화살]이 ${aoeTarget.constructor.name}에게 피해를 입힙니다!`, color: '#add8e6' });

--- a/src/micro/WeaponAI.js
+++ b/src/micro/WeaponAI.js
@@ -42,28 +42,21 @@ export class SwordAI extends BaseWeaponAI {
 
 export class DaggerAI extends BaseWeaponAI {
     decideAction(wielder, weapon, context) {
-        const { enemies, mapManager } = context;
+        const { enemies } = context;
         if (!enemies || enemies.length === 0) return { type: 'idle' };
 
-        const nearest = enemies.reduce((prev, curr) => {
-            const prevDist = Math.hypot(prev.x - wielder.x, prev.y - wielder.y);
-            const currDist = Math.hypot(curr.x - wielder.x, curr.y - wielder.y);
-            return prevDist < currDist ? prev : curr;
-        });
-
+        const nearest = enemies.sort((a,b)=>Math.hypot(a.x-wielder.x,a.y-wielder.y)-Math.hypot(b.x-wielder.x,b.y-wielder.y))[0];
         const distance = Math.hypot(nearest.x - wielder.x, nearest.y - wielder.y);
 
         if (distance <= wielder.attackRange) {
             return { type: 'attack', target: nearest };
         }
 
-        const facing = nearest.facing || { x: 0, y: 0 };
-        const tileSize = mapManager?.tileSize ?? 32;
-        const behindX = nearest.x - facing.x * (tileSize * 0.8);
-        const behindY = nearest.y - facing.y * (tileSize * 0.8);
-        const behindTarget = { x: behindX, y: behindY };
+        if (nearest.direction === undefined && !nearest.facing) {
+            return { type: 'move', target: { x: nearest.x, y: nearest.y } };
+        }
 
-        return { type: 'move', target: behindTarget };
+        return { type: 'backstab_teleport', target: nearest };
     }
 }
 


### PR DESCRIPTION
## Summary
- improve VFXManager with shockwave and teleport effects
- modify DaggerAI to use backstab teleport
- extend MotionManager dash with trail and strike visuals
- handle new action types in AI manager
- trigger shockwave on sonic arrow hit
- hide teleported units when rendering
- customize dash trail effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685645517fdc8327ae7dfb2a1f834334