### PR TITLE
Implement poison and freeze status ailments

### DIFF
--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -75,11 +75,37 @@ export const EFFECTS = {
     // 상태이상
     poison: {
         name: '중독',
-        type: 'dot', // Damage over Time
-        duration: 500, // 5턴 (100프레임당 1턴 기준)
-        damagePerTurn: 2,
-        tags: ['status_ailment', 'poison'],
+        type: 'dot',
+        duration: 500, // 5턴
+        damagePerTurn: 3,
+        tags: ['status_ailment', 'poison', 'dot'],
         iconKey: 'parasite',
+        overlayColor: 'rgba(0, 255, 0, 0.3)',
+        particle: {
+            type: 'bubble',
+            color: 'rgba(100, 200, 100, 0.7)',
+            gravity: -0.02,
+            speed: 0.4,
+        },
+    },
+    freeze: {
+        name: '동결',
+        type: 'dot_cc',
+        duration: 300,
+        damagePerTurn: 1,
+        tags: ['status_ailment', 'freeze', 'dot', 'cc'],
+        stats: {
+            movementSpeed: -2,
+            attackSpeed: -0.5,
+            castingSpeed: -0.5,
+        },
+        overlayColor: 'rgba(100, 150, 255, 0.4)',
+        particle: {
+            type: 'snowflake',
+            color: 'rgba(200, 220, 255, 0.9)',
+            gravity: 0.05,
+            speed: 0.5,
+        },
     },
 
     shield: {

--- a/src/entities.js
+++ b/src/entities.js
@@ -135,9 +135,19 @@ class Entity {
         ctx.fill();
 
         // 2. 유닛 이미지 그리기 (yOffset 적용)
+        const statusEffect = this.effects.find(e => e.overlayColor);
+
         ctx.scale(this.direction || 1, 1);
         if (this.image) {
-            ctx.drawImage(this.image, -this.width / 2, -this.height + yOffset, this.width, this.height);
+            ctx.drawImage(this.image, -this.width / 2, -
+                this.height + yOffset, this.width, this.height);
+        }
+
+        if (statusEffect) {
+            ctx.globalCompositeOperation = 'source-atop';
+            ctx.fillStyle = statusEffect.overlayColor;
+            ctx.fillRect(-this.width / 2, -this.height + yOffset, this.width, this.height);
+            ctx.globalCompositeOperation = 'source-over';
         }
 
         // 3. 장비 그리기 (yOffset 적용)

--- a/src/game.js
+++ b/src/game.js
@@ -119,11 +119,17 @@ export class Game {
                 name !== 'VFXManager' &&
                 name !== 'ItemManager' &&
                 name !== 'AuraManager' &&
-                name !== 'ItemAIManager'
+                name !== 'ItemAIManager' &&
+                name !== 'EffectManager'
         );
         for (const managerName of otherManagerNames) {
             this.managers[managerName] = new Managers[managerName](this.eventManager, assets, this.factory);
         }
+
+        this.managers.EffectManager = new Managers.EffectManager(
+            this.eventManager,
+            this.managers.VFXManager
+        );
 
         this.monsterManager = this.managers.MonsterManager;
         this.mercenaryManager = this.managers.MercenaryManager;

--- a/src/managers/effectManager.js
+++ b/src/managers/effectManager.js
@@ -1,70 +1,117 @@
 import { EFFECTS } from '../data/effects.js';
 
 export class EffectManager {
-    constructor(eventManager) {
+    constructor(eventManager, vfxManager = null) {
         this.eventManager = eventManager;
+        this.vfxManager = vfxManager;
         console.log("[EffectManager] Initialized");
     }
 
-    // 특정 유닛에게 효과를 추가하는 함수
     addEffect(target, effectId) {
         const effectData = EFFECTS[effectId];
         if (!effectData) return;
 
-        // 이미 같은 효과가 걸려있다면, 지속시간만 갱신 (나중에 중첩 로직 추가 가능)
         const existingEffect = target.effects.find(e => e.id === effectId);
         if (existingEffect) {
             existingEffect.remaining = effectData.duration;
-        } else {
-            const newEffect = { id: effectId, ...effectData, remaining: effectData.duration };
-            target.effects.push(newEffect);
-            if (effectData.type === 'shield') {
-                target.shield = (target.shield || 0) + effectData.shieldAmount;
-            } else if (effectData.type === 'damage_buff') {
-                target.damageBonus = (target.damageBonus || 0) + effectData.bonusDamage;
+            return;
+        }
+
+        const newEffect = {
+            id: effectId,
+            ...effectData,
+            remaining: effectData.duration,
+            emitter: null,
+        };
+
+        if (this.vfxManager && newEffect.particle) {
+            newEffect.emitter = this.vfxManager.addEmitter(target.x, target.y, {
+                followTarget: target,
+                offsetX: target.width / 2,
+                offsetY: target.height / 2,
+                spawnRate: 2,
+                duration: -1,
+                particleOptions: newEffect.particle,
+            });
+        }
+
+        if (newEffect.stats && target.stats) {
+            for (const [stat, val] of Object.entries(newEffect.stats)) {
+                const baseKey = stat === 'movementSpeed' ? 'movement' : stat;
+                target.stats.increaseBaseStat(baseKey, val);
             }
         }
 
-        // 효과가 적용되면 스탯을 다시 계산하도록 이벤트 발행
+        if (newEffect.type === 'shield') {
+            target.shield = (target.shield || 0) + newEffect.shieldAmount;
+        } else if (newEffect.type === 'damage_buff') {
+            target.damageBonus = (target.damageBonus || 0) + newEffect.bonusDamage;
+        }
+
+        target.effects.push(newEffect);
+        this.eventManager.publish('stats_changed', { entity: target });
+    }
+
+    removeEffect(target, effect) {
+        if (this.vfxManager && effect.emitter) {
+            this.vfxManager.removeEmitter(effect.emitter);
+            effect.emitter = null;
+        }
+
+        if (effect.stats && target.stats) {
+            for (const [stat, val] of Object.entries(effect.stats)) {
+                const baseKey = stat === 'movementSpeed' ? 'movement' : stat;
+                target.stats.increaseBaseStat(baseKey, -val);
+            }
+        }
+
+        if (effect.type === 'shield') {
+            target.shield = Math.max(0, target.shield - (effect.shieldAmount || 0));
+        } else if (effect.type === 'damage_buff') {
+            target.damageBonus = Math.max(0, target.damageBonus - (effect.bonusDamage || 0));
+        }
+
+        target.effects = target.effects.filter(e => e !== effect);
         this.eventManager.publish('stats_changed', { entity: target });
     }
 
     removeEffectsByTag(target, tag) {
         if (!target.effects || target.effects.length === 0) return;
-        const initialCount = target.effects.length;
-        target.effects = target.effects.filter(eff => !(eff.tags && eff.tags.includes(tag)));
-        if (target.effects.length < initialCount) {
-            this.eventManager.publish('stats_changed', { entity: target });
+        for (const effect of [...target.effects]) {
+            if (effect.tags && effect.tags.includes(tag)) {
+                this.removeEffect(target, effect);
+            }
         }
     }
 
-    // 매 프레임 모든 유닛의 효과를 업데이트
     update(entities) {
         entities.forEach(entity => {
             if (entity.effects.length === 0) return;
 
-            entity.effects.forEach(effect => {
+            for (let i = entity.effects.length - 1; i >= 0; i--) {
+                const effect = entity.effects[i];
                 effect.remaining--;
 
-                if (effect.type === 'dot' && effect.remaining % 100 === 0) {
+                if (effect.damagePerTurn && effect.remaining % 100 === 0) {
                     entity.takeDamage(effect.damagePerTurn);
+                    this.eventManager.publish('log', {
+                        message: `[${effect.name}] 효과로 ${entity.constructor.name}가 ${effect.damagePerTurn}의 피해를 입었습니다.`,
+                        color: 'orange',
+                    });
                 }
-            });
 
-            const initialCount = entity.effects.length;
-            entity.effects = entity.effects.filter(effect => {
-                if (effect.remaining > 0) return true;
-
-                if (effect.type === 'shield') {
-                    entity.shield = Math.max(0, entity.shield - (effect.shieldAmount || 0));
-                } else if (effect.type === 'damage_buff') {
-                    entity.damageBonus = Math.max(0, entity.damageBonus - (effect.bonusDamage || 0));
+                if (effect.remaining % 100 === 0 && Math.random() < 0.1) {
+                    this.eventManager.publish('log', {
+                        message: `${entity.constructor.name}가 [${effect.name}] 효과를 이겨냈습니다!`,
+                        color: 'lightgreen',
+                    });
+                    this.removeEffect(entity, effect);
+                    continue;
                 }
-                return false;
-            });
 
-            if (entity.effects.length < initialCount) {
-                this.eventManager.publish('stats_changed', { entity });
+                if (effect.remaining <= 0) {
+                    this.removeEffect(entity, effect);
+                }
             }
         });
     }

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -163,6 +163,7 @@ export class VFXManager {
      */
     addEmitter(x, y, options = {}) {
         const emitter = {
+            id: Math.random().toString(36).substr(2, 9),
             x,
             y,
             spawnRate: options.spawnRate || 2,

--- a/tests/effectManager.test.js
+++ b/tests/effectManager.test.js
@@ -1,5 +1,6 @@
 import { EffectManager } from '../src/managers/effectManager.js';
 import { EventManager } from '../src/managers/eventManager.js';
+import { StatManager } from '../src/stats.js';
 import { describe, test, assert } from './helpers.js';
 
 describe('Managers', () => {
@@ -7,7 +8,7 @@ describe('Managers', () => {
 test('버프 추가', () => {
     const eventManager = new EventManager();
     const effectManager = new EffectManager(eventManager);
-    const mockTarget = { effects: [], stats: { recalculate: () => {} } };
+    const mockTarget = { effects: [], stats: { recalculate: () => {}, increaseBaseStat: () => {} } };
     let eventFired = false;
     eventManager.subscribe('stats_changed', () => { eventFired = true; });
 
@@ -21,7 +22,7 @@ test('버프 추가', () => {
 test('보호막 적용 및 만료', () => {
     const eventManager = new EventManager();
     const effectManager = new EffectManager(eventManager);
-    const target = { effects: [], stats: { recalculate: () => {} }, shield: 0, damageBonus: 0, takeDamage: () => {} };
+    const target = { effects: [], stats: { recalculate: () => {}, increaseBaseStat: () => {} }, shield: 0, damageBonus: 0, takeDamage: () => {} };
     effectManager.addEffect(target, 'shield');
     assert.strictEqual(target.shield, 10);
     effectManager.update([target]);
@@ -34,12 +35,26 @@ test('독 도트 피해', () => {
     const eventManager = new EventManager();
     const effectManager = new EffectManager(eventManager);
     let damageTaken = 0;
-    const target = { effects: [], stats: { recalculate: () => {} }, shield: 0, damageBonus: 0,
+    const target = { effects: [], stats: { recalculate: () => {}, increaseBaseStat: () => {} }, shield: 0, damageBonus: 0,
                      takeDamage: (d) => { damageTaken += d; } };
     effectManager.addEffect(target, 'poison');
     // Simulate 100 frames (1 turn)
     for (let i = 0; i < 100; i++) effectManager.update([target]);
-    assert.strictEqual(damageTaken, 2);
+    assert.strictEqual(damageTaken, 3);
+});
+
+test('동결 이동 속도 감소', () => {
+    const eventManager = new EventManager();
+    const effectManager = new EffectManager(eventManager);
+    const stats = new StatManager({}, { movement: 4 });
+    const target = { effects: [], stats, shield: 0, damageBonus: 0, takeDamage: () => {} };
+    const base = stats.get('movementSpeed');
+    effectManager.addEffect(target, 'freeze');
+    stats.recalculate();
+    assert.strictEqual(stats.get('movementSpeed'), base - 2);
+    effectManager.removeEffect(target, target.effects[0]);
+    stats.recalculate();
+    assert.strictEqual(stats.get('movementSpeed'), base);
 });
 
 });


### PR DESCRIPTION
## Summary
- extend `EFFECTS` with poison and new freeze effect data
- overlay status color in entity rendering
- allow VFX emitters to have ids
- overhaul `EffectManager` to handle stats, particles and resistance rolls
- inject VFX manager when creating EffectManager
- map `movementSpeed` stat name to base `movement`
- test freeze movement slowdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856755a82208327b2af1e32708d90eb