### PR TITLE
Add AI override status effects

### DIFF
--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -205,5 +205,53 @@ export const EFFECTS = {
         stats: { defense: 15, magicResist: -15 }, // 방어력 증가, 마법저항력 감소
         tags: ['status_ailment', 'cc', 'petrify'],
         overlayColor: 'rgba(150, 150, 150, 0.7)',
+    },
+
+    // --- 3단계 상태이상 ---
+    silence: {
+        name: '침묵',
+        type: 'debuff', // 스킬 사용만 막으므로 cc는 아님
+        duration: 400,
+        tags: ['status_ailment', 'silence'],
+        particle: { type: 'text', text: '...', color: 'grey' }
+    },
+    blind: {
+        name: '실명',
+        type: 'debuff',
+        duration: 500,
+        stats: { visionRange: -300 }, // 시야 대폭 감소
+        tags: ['status_ailment', 'blind'],
+        overlayColor: 'rgba(50, 50, 50, 0.5)',
+        particle: { type: 'aura', color: 'rgba(20, 20, 20, 0.4)' }
+    },
+    fear: {
+        name: '공포',
+        type: 'ai_override', // AI를 덮어쓰는 타입
+        duration: 300,
+        tags: ['status_ailment', 'cc', 'fear', 'ai_override'],
+        particle: { type: 'aura', color: 'rgba(128, 0, 128, 0.4)'}
+    },
+    confusion: {
+        name: '혼란',
+        type: 'ai_override',
+        duration: 500,
+        tags: ['status_ailment', 'cc', 'confusion', 'ai_override'],
+        particle: { type: 'text', text: '???', color: 'orange' }
+    },
+    berserk: {
+        name: '광폭화',
+        type: 'ai_override',
+        duration: 400,
+        stats: { attackPower: 10, attackSpeed: 0.5, movementSpeed: 2 },
+        tags: ['status_ailment', 'berserk', 'ai_override'],
+        overlayColor: 'rgba(255, 0, 0, 0.3)',
+        particle: { type: 'aura', color: 'rgba(200, 0, 0, 0.5)' }
+    },
+    charm: {
+        name: '매혹',
+        type: 'ai_override',
+        duration: 600,
+        tags: ['status_ailment', 'cc', 'charm', 'ai_override'],
+        particle: { type: 'heart', color: 'rgba(255, 105, 180, 0.9)' }
     }
 };

--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -76,6 +76,11 @@ export class MetaAIManager {
                 }
                 break;
             case 'skill':
+                const isSilenced = entity.effects?.some(e => e.id === 'silence');
+                if (isSilenced) {
+                    eventManager.publish('log', { message: `[침묵] 상태라 스킬을 사용할 수 없습니다.`, color: 'grey' });
+                    break;
+                }
                 const skill = SKILLS[action.skillId];
                 if (
                     skill &&

--- a/src/managers/possessionAIManager.js
+++ b/src/managers/possessionAIManager.js
@@ -1,5 +1,6 @@
 // src/managers/possessionAIManager.js
 import { SKILLS } from '../data/skills.js';
+import { FearAI, ConfusionAI, BerserkAI, CharmAI } from '../ai.js';
 
 export class PossessionAIManager {
     constructor(eventManager) {
@@ -100,9 +101,27 @@ export class PossessionAIManager {
                 possessedCC: hostilePossessed.filter(e => e.possessedBy?.constructor.name === 'CCGhostAI'),
             };
             for (const entity of hostilePossessed) {
-                if (entity.possessedBy) {
-                    const action = entity.possessedBy.decideAction(entity, hostileContext);
-                    context.metaAIManager.executeAction(entity, action, hostileContext);
+                if (entity.hp > 0) {
+                    const overrideEffect = entity.effects.find(e => e.type === 'ai_override');
+                    if (overrideEffect) {
+                        let overrideAI;
+                        switch (overrideEffect.id) {
+                            case 'fear': overrideAI = new FearAI(); break;
+                            case 'confusion': overrideAI = new ConfusionAI(); break;
+                            case 'berserk': overrideAI = new BerserkAI(); break;
+                            case 'charm': overrideAI = new CharmAI(); break;
+                        }
+                        if (overrideAI) {
+                            const action = overrideAI.decideAction(entity, hostileContext);
+                            context.metaAIManager.executeAction(entity, action, hostileContext);
+                            continue;
+                        }
+                    }
+
+                    if (entity.possessedBy) {
+                        const action = entity.possessedBy.decideAction(entity, hostileContext);
+                        context.metaAIManager.executeAction(entity, action, hostileContext);
+                    }
                 }
             }
         }
@@ -120,9 +139,27 @@ export class PossessionAIManager {
                 possessedCC: friendlyPossessed.filter(e => e.possessedBy?.constructor.name === 'CCGhostAI'),
             };
             for (const entity of friendlyPossessed) {
-                if (entity.possessedBy) {
-                    const action = entity.possessedBy.decideAction(entity, friendlyContext);
-                    context.metaAIManager.executeAction(entity, action, friendlyContext);
+                if (entity.hp > 0) {
+                    const overrideEffect = entity.effects.find(e => e.type === 'ai_override');
+                    if (overrideEffect) {
+                        let overrideAI;
+                        switch (overrideEffect.id) {
+                            case 'fear': overrideAI = new FearAI(); break;
+                            case 'confusion': overrideAI = new ConfusionAI(); break;
+                            case 'berserk': overrideAI = new BerserkAI(); break;
+                            case 'charm': overrideAI = new CharmAI(); break;
+                        }
+                        if (overrideAI) {
+                            const action = overrideAI.decideAction(entity, friendlyContext);
+                            context.metaAIManager.executeAction(entity, action, friendlyContext);
+                            continue;
+                        }
+                    }
+
+                    if (entity.possessedBy) {
+                        const action = entity.possessedBy.decideAction(entity, friendlyContext);
+                        context.metaAIManager.executeAction(entity, action, friendlyContext);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- define new status ailments with `ai_override` type like Fear, Confusion, Berserk and Charm
- implement dedicated AI classes for these effects
- let MetaAIManager and PossessionAIManager prioritize the override AI
- block skill usage when silenced and compute vision range from stats
- enable blind effect and adjust AI to use stats-based vision
- prioritize override AI even when unit is crowd controlled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68567f95d8bc8327836050c89042be4c