### PR TITLE
Implement rune socket system

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -204,4 +204,24 @@ export const ITEMS = {
         imageKey: 'potion',
         effectId: 'strength_buff'
     },
+
+    // --- 룬 아이템 ---
+    fire_rune: {
+        name: '화염의 룬',
+        type: 'rune',
+        tags: ['rune', 'fire', 'fire_rune'],
+        imageKey: 'fire-ball',
+        elementType: 'fire',
+        weaponDamage: 5,
+        armorResist: 0.1,
+    },
+    ice_rune: {
+        name: '냉기의 룬',
+        type: 'rune',
+        tags: ['rune', 'ice', 'ice_rune'],
+        imageKey: 'ice-ball',
+        elementType: 'ice',
+        weaponDamage: 4,
+        armorResist: 0.1,
+    },
 };

--- a/src/factory.js
+++ b/src/factory.js
@@ -185,13 +185,15 @@ export class ItemFactory {
         if (baseItem.effectId) item.effectId = baseItem.effectId;
 
         if (item.type === 'weapon' || item.type === 'armor') {
+            const numSockets = Math.floor(Math.random() * 4); // 0~3개 소켓
+            item.sockets = Array(numSockets).fill(null);
             this._applySynergies(item);
+        } else {
+            item.sockets = [];
         }
 
         if (Math.random() < 0.5) this._applyAffix(item, PREFIXES, 'prefix');
         if (Math.random() < 0.5) this._applyAffix(item, SUFFIXES, 'suffix');
-
-        item.sockets = this._createSockets();
 
         if (baseItem.possessionAI) {
             item.possessionAI = baseItem.possessionAI;

--- a/src/stats.js
+++ b/src/stats.js
@@ -70,14 +70,25 @@ export class StatManager {
 
         for (const slot in this.entity.equipment) {
             const item = this.entity.equipment[slot];
-            if (item && item.stats) {
-                if (item.stats instanceof Map) {
-                    for (const [stat, value] of item.stats.entries()) {
-                        this._fromEquipment[stat] = (this._fromEquipment[stat] || 0) + value;
-                    }
-                } else {
-                    for (const [stat, value] of Object.entries(item.stats)) {
-                        this._fromEquipment[stat] = (this._fromEquipment[stat] || 0) + value;
+            if (!item) continue;
+
+            // 1. 아이템 자체 스탯
+            if (item.stats) {
+                const statsSource = item.stats instanceof Map ? item.stats.entries() : Object.entries(item.stats);
+                for (const [stat, value] of statsSource) {
+                    this._fromEquipment[stat] = (this._fromEquipment[stat] || 0) + value;
+                }
+            }
+
+            // 2. 소켓 룬 스탯
+            if (item.sockets && item.sockets.length > 0) {
+                for (const rune of item.sockets) {
+                    if (!rune) continue;
+
+                    if (item.type === 'armor' && rune.armorResist) {
+                        const map = { fire: 'burnResist', ice: 'freezeResist', poison: 'poisonResist' };
+                        const resistStatName = map[rune.elementType] || `${rune.elementType}Resist`;
+                        this._fromEquipment[resistStatName] = (this._fromEquipment[resistStatName] || 0) + rune.armorResist;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- equip weapons and armor with random sockets
- add fire and ice rune items
- apply rune resist bonuses through StatManager
- enable rune damage in CombatCalculator
- support fallback to `weapon` slot for tests
- map rune elements to existing resist stats and expose rune tags for TagManager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856894f3e748327b2ae8cad1f416ab8