### PR TITLE
Fix airborne rendering issues and update spawn behavior

### DIFF
--- a/src/entities.js
+++ b/src/entities.js
@@ -156,10 +156,9 @@ class Entity {
             ctx.globalCompositeOperation = 'source-over';
         }
 
-        // 3. 장비 그리기 (yOffset 적용)
+        // 3. 장비 그리기 (본체와 동일한 변환 적용)
         if (this.equipmentRenderManager) {
             ctx.save();
-            ctx.translate(0, yOffset); // 장비도 유닛을 따라 위로 이동
             this.equipmentRenderManager.drawEquipment(ctx, this);
             ctx.restore();
         }

--- a/src/factory.js
+++ b/src/factory.js
@@ -19,6 +19,7 @@ import { SYNERGIES } from './data/synergies.js';
 export class CharacterFactory {
     constructor(assets) {
         this.assets = assets;
+        this.itemFactory = new ItemFactory(assets);
     }
 
     create(type, config) {
@@ -80,7 +81,8 @@ export class CharacterFactory {
                 if (config.jobId === 'archer') {
                     const rangedSkill = Math.random() < 0.5 ? SKILLS.double_thrust.id : SKILLS.hawk_eye.id;
                     merc.skills.push(rangedSkill);
-                    merc.equipment.weapon = { tags: ['weapon', 'ranged', 'bow'] };
+                    const bow = this.itemFactory.create('long_bow', 0, 0, tileSize);
+                    if (bow) merc.equipment.weapon = bow;
                     merc.fallbackAI = new RangedAI();
                 } else if (config.jobId === 'warrior') {
                     merc.skills.push(SKILLS.charge_attack.id);
@@ -99,11 +101,17 @@ export class CharacterFactory {
                 } else if (config.jobId === 'bard') {
                     merc.skills.push(SKILLS.guardian_hymn.id);
                     merc.skills.push(SKILLS.courage_hymn.id);
-                    merc.equipment.weapon = { tags: ['weapon', 'ranged', 'bow', 'song'] };
+                    const vb = this.itemFactory.create('violin_bow', 0, 0, tileSize);
+                    if (vb) merc.equipment.weapon = vb;
                     merc.roleAI = new BardAI();
                 } else {
                     const skillId = Math.random() < 0.5 ? SKILLS.double_strike.id : SKILLS.charge_attack.id;
                     merc.skills.push(skillId);
+                }
+
+                if (!merc.equipment.weapon) {
+                    const sword = this.itemFactory.create('sword', 0, 0, tileSize);
+                    if (sword) merc.equipment.weapon = sword;
                 }
 
                 return merc;

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -17,18 +17,33 @@ export class AquariumManager {
         this.allWeaponIds = ['short_sword', 'long_bow', 'estoc', 'axe', 'mace', 'staff', 'spear', 'scythe', 'whip', 'dagger', 'violin_bow'];
     }
 
+    _findSpacedPosition(minDist = this.mapManager.tileSize * 4) {
+        for (let i = 0; i < 30; i++) {
+            const pos = this.mapManager.getRandomFloorPosition();
+            if (!pos) continue;
+            const tooClose = this.monsterManager.monsters.some(m => {
+                const dx = m.x - pos.x;
+                const dy = m.y - pos.y;
+                return Math.hypot(dx, dy) < minDist;
+            });
+            if (!tooClose) return pos;
+        }
+        return this.mapManager.getRandomFloorPosition();
+    }
+
     addTestingFeature(feature) {
         this.features.push(feature);
         if (feature.type === 'monster') {
-            const pos = this.mapManager.getRandomFloorPosition();
+            const pos = this._findSpacedPosition(this.mapManager.tileSize * 6);
             if (pos) {
+                const vision = feature.baseStats?.visionRange ?? this.mapManager.tileSize * 2;
                 const monster = this.charFactory.create('monster', {
                     x: pos.x,
                     y: pos.y,
                     tileSize: this.mapManager.tileSize,
                     groupId: 'dungeon_monsters',
                     image: feature.image,
-                    baseStats: feature.baseStats || {}
+                    baseStats: { ...feature.baseStats, visionRange: vision }
                 });
                 if (this.traitManager) {
                     this.traitManager.applyTraits(monster, TRAITS);

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -343,11 +343,17 @@ export class VFXManager {
     addTextPopup(text, target, options = {}) {
         if (!target) return;
         const duration = options.duration || 30;
+        const baseOffset =
+            options.offsetY !== undefined ? options.offsetY : (target.height || 0);
+        let finalOffset = baseOffset;
+        if (Array.isArray(target.effects) && target.effects.some(e => e.id === 'airborne')) {
+            finalOffset += (target.height || 0) * 0.5;
+        }
         const effect = {
             type: 'text_popup',
             text,
             x: target.x + (target.width || 0) / 2,
-            y: target.y - (options.offsetY || (target.height || 0) * 0.5),
+            y: target.y - finalOffset,
             duration,
             life: duration,
             color: options.color || 'white',


### PR DESCRIPTION
## Summary
- render equipment aligned with entity when airborne
- boost text popup offset logic so MBTI letters remain visible
- give mercenaries real weapons via ItemFactory so proficiency skills trigger
- space out aquarium mobs and halve their default vision range

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685693a1ae508327aa5ad6b741dd0a49