### PR TITLE
Reduce aquarium monster spawn

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -221,7 +221,9 @@ export class Game {
         }
 
         // example feature: spawn several monsters for poison debuff testing
-        for (let i = 0; i < 20; i++) {
+        // The aquarium used to spawn 20 basic monsters, which was excessive
+        // for early testing. Reduce the count by half for better breathing room.
+        for (let i = 0; i < 10; i++) {
             this.aquariumManager.addTestingFeature({
                 type: 'monster',
                 image: assets.monster,


### PR DESCRIPTION
## Summary
- tone down aquarium monster spam by cutting the test spawn loop to 10

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685697e5fcf48327bb11601e078f7c82