### PR TITLE
Adjust aquarium monster stats

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -34,6 +34,7 @@ import { PossessionAIManager } from './managers/possessionAIManager.js';
 import { Ghost } from './entities.js';
 import { TankerGhostAI, RangedGhostAI, SupporterGhostAI, CCGhostAI } from './ai.js';
 import { EMBLEMS } from './data/emblems.js';
+import { adjustMonsterStatsForAquarium } from './utils/aquariumUtils.js';
 
 export class Game {
     constructor() {
@@ -328,13 +329,17 @@ export class Game {
         for (let i = 0; i < 40; i++) {
             const pos = this.mapManager.getRandomFloorPosition();
             if (pos) {
+                let stats = {};
+                if (this.mapManager.name === 'aquarium') {
+                    stats = adjustMonsterStatsForAquarium(stats);
+                }
                 const monster = this.factory.create('monster', {
                     x: pos.x,
                     y: pos.y,
                     tileSize: this.mapManager.tileSize,
                     groupId: this.monsterGroup.id,
                     image: assets.monster,
-                    baseStats: {}
+                    baseStats: stats
                 });
                 monster.equipmentRenderManager = this.equipmentRenderManager;
                 // 몬스터 초기 장비 및 소지품 설정

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -2,6 +2,7 @@
 // Manages patches and features placed on the Aquarium map
 import { TRAITS } from '../data/traits.js';
 import { EquipmentManager } from './equipmentManager.js';
+import { adjustMonsterStatsForAquarium } from '../utils/aquariumUtils.js';
 export class AquariumManager {
     constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory, vfxManager = null, traitManager = null) {
         this.eventManager = eventManager;
@@ -37,13 +38,17 @@ export class AquariumManager {
             const pos = this._findSpacedPosition(this.mapManager.tileSize * 6);
             if (pos) {
                 const vision = feature.baseStats?.visionRange ?? this.mapManager.tileSize * 2;
+                const stats = adjustMonsterStatsForAquarium({
+                    ...feature.baseStats,
+                    visionRange: vision,
+                });
                 const monster = this.charFactory.create('monster', {
                     x: pos.x,
                     y: pos.y,
                     tileSize: this.mapManager.tileSize,
                     groupId: 'dungeon_monsters',
                     image: feature.image,
-                    baseStats: { ...feature.baseStats, visionRange: vision }
+                    baseStats: stats,
                 });
                 if (this.traitManager) {
                     this.traitManager.applyTraits(monster, TRAITS);

--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -1,4 +1,5 @@
 import { TRAITS } from '../data/traits.js';
+import { adjustMonsterStatsForAquarium } from '../utils/aquariumUtils.js';
 
 export class MonsterManager {
     constructor(a = null, b = null, c = null, d = null, e = 0) {
@@ -39,13 +40,17 @@ export class MonsterManager {
         for (let i = 0; i < count; i++) {
             const pos = this.mapManager.getRandomFloorPosition();
             if (pos) {
+                let stats = {};
+                if (this.mapManager.name === 'aquarium') {
+                    stats = adjustMonsterStatsForAquarium(stats);
+                }
                 const monster = this.factory.create('monster', {
                     x: pos.x,
                     y: pos.y,
                     tileSize: this.mapManager.tileSize,
                     groupId: 'dungeon_monsters',
                     image: this.assets?.monster,
-                    baseStats: {}
+                    baseStats: stats
                 });
                 this.monsters.push(monster);
             }

--- a/src/utils/aquariumUtils.js
+++ b/src/utils/aquariumUtils.js
@@ -1,0 +1,21 @@
+// src/utils/aquariumUtils.js
+// Utility functions for the Aquarium map
+
+/**
+ * Adjusts base stats so monsters have zero attack power and double health.
+ * @param {object} baseStats
+ * @returns {object} adjusted copy of baseStats
+ */
+export function adjustMonsterStatsForAquarium(baseStats = {}) {
+    const strength = baseStats.strength ?? 1;
+    const endurance = baseStats.endurance ?? 1;
+    const adjusted = { ...baseStats };
+
+    // attackPower formula in StatManager: baseAP + 1 + strength * 2
+    adjusted.attackPower = -1 - strength * 2;
+
+    // For maxHp = 10 + endurance * 5. We want double the original value.
+    adjusted.endurance = 2 + 2 * endurance;
+
+    return adjusted;
+}


### PR DESCRIPTION
## Summary
- add `adjustMonsterStatsForAquarium` helper
- spawn aquarium monsters with 0 attack power and double HP
- hook utility into AquariumManager, game initialization, and MonsterManager

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68569b1b0ba88327afe7189630e31752