### PR TITLE
Fix aquarium monster stats and knockback flow

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -615,7 +615,15 @@ export class Game {
             const { attacker, defender, distance } = data;
 
             if (this.motionManager) {
-                this.motionManager.knockbackTarget(defender, attacker, distance, this.vfxManager);
+                const result = this.motionManager.knockbackTarget(defender, attacker, distance);
+                if (result) {
+                    eventManager.publish('vfx_request', {
+                        type: 'knockback_animation',
+                        target: defender,
+                        fromPos: result.fromPos,
+                        toPos: result.toPos,
+                    });
+                }
             }
         });
 
@@ -914,6 +922,8 @@ export class Game {
                 }
             } else if (data.type === 'text_popup') {
                 this.vfxManager.addTextPopup(data.text, data.target, data.options || {});
+            } else if (data.type === 'knockback_animation') {
+                this.vfxManager.addKnockbackAnimation(data.target, data.fromPos, data.toPos);
             }
         });
 

--- a/src/managers/motionManager.js
+++ b/src/managers/motionManager.js
@@ -91,28 +91,28 @@ export class MotionManager {
 
     /**
      * 대상을 공격자로부터 멀어지는 방향으로 밀어냅니다.
+     * 이동 결과를 반환하여 시각 효과는 외부에서 처리하도록 합니다.
      * @param {Entity} target - 밀려날 대상
      * @param {Entity} source - 공격자
      * @param {number} distance - 밀려날 거리
-     * @param {VFXManager} vfxManager - 애니메이션을 위한 VFX 매니저
+     * @returns {{fromPos:{x:number,y:number}, toPos:{x:number,y:number}}|null}
      */
-    knockbackTarget(target, source, distance, vfxManager) {
+    knockbackTarget(target, source, distance) {
         const angle = Math.atan2(target.y - source.y, target.x - source.x);
         const destX = target.x + Math.cos(angle) * distance;
         const destY = target.y + Math.sin(angle) * distance;
 
         if (this.mapManager.isWallAt(destX, destY, target.width, target.height)) {
             console.log('[MotionManager] 넉백 실패: 목적지에 벽이 있음');
-            return;
+            return null;
         }
 
-        if (vfxManager) {
-            const fromPos = { x: target.x, y: target.y };
-            const toPos = { x: destX, y: destY };
-            vfxManager.addKnockbackAnimation(target, fromPos, toPos);
-        } else {
-            target.x = destX;
-            target.y = destY;
-        }
+        const fromPos = { x: target.x, y: target.y };
+        const toPos = { x: destX, y: destY };
+
+        target.x = destX;
+        target.y = destY;
+
+        return { fromPos, toPos };
     }
 }

--- a/src/utils/aquariumUtils.js
+++ b/src/utils/aquariumUtils.js
@@ -2,20 +2,28 @@
 // Utility functions for the Aquarium map
 
 /**
- * Adjusts base stats so monsters have zero attack power and double health.
+ * Adjusts base stats so monsters spawn with almost no attack power and
+ * double the normal amount of health. This function reverses the formulas
+ * in StatManager to calculate the minimal stat changes required.
  * @param {object} baseStats
  * @returns {object} adjusted copy of baseStats
  */
 export function adjustMonsterStatsForAquarium(baseStats = {}) {
     const strength = baseStats.strength ?? 1;
     const endurance = baseStats.endurance ?? 1;
+    const baseAP = baseStats.attackPower ?? 0;
+
     const adjusted = { ...baseStats };
 
-    // attackPower formula in StatManager: baseAP + 1 + strength * 2
-    adjusted.attackPower = -1 - strength * 2;
+    // StatManager derives attackPower as: baseAP + 1 + strength * 2
+    // To end up with ~0 attack power we solve the formula for strength.
+    adjusted.strength = (0 - baseAP - 1) / 2;
 
-    // For maxHp = 10 + endurance * 5. We want double the original value.
-    adjusted.endurance = 2 + 2 * endurance;
+    // StatManager derives maxHp as: 10 + endurance * 5
+    // Double the final value while keeping other bonuses intact.
+    const originalHp = 10 + endurance * 5;
+    const targetHp = originalHp * 2;
+    adjusted.endurance = (targetHp - 10) / 5;
 
     return adjusted;
 }

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -5,6 +5,8 @@ import { EventManager } from '../src/managers/eventManager.js';
 import { MonsterManager } from '../src/managers/monsterManager.js';
 import { ItemManager } from '../src/managers/itemManager.js';
 import { VFXManager } from '../src/managers/vfxManager.js';
+import { adjustMonsterStatsForAquarium } from '../src/utils/aquariumUtils.js';
+import { StatManager } from '../src/stats.js';
 import { describe, test, assert } from './helpers.js';
 
 const assets = { monster:{} };
@@ -39,5 +41,14 @@ describe('Aquarium', () => {
         const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx, null);
         aquariumManager.addTestingFeature({ type: 'bubble' });
         assert.strictEqual(vfx.emitters.length, 1);
+    });
+
+    test('Monster stats adjusted for aquarium', () => {
+        const base = { strength: 5, endurance: 3 };
+        const adjusted = adjustMonsterStatsForAquarium(base);
+        const dummy = { hp: 0, mp: 0 };
+        const stats = new StatManager(dummy, adjusted);
+        assert.strictEqual(stats.get('maxHp'), (10 + base.endurance * 5) * 2);
+        assert.ok(Math.abs(stats.get('attackPower')) < 0.001);
     });
 });


### PR DESCRIPTION
## Summary
- adjust aquarium monster stats using formulas in `StatManager`
- decouple knockback animation from `MotionManager`
- trigger VFX knockback via `vfx_request`
- cover new stats behaviour in `aquarium.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856a446e7788327acb572edaa7362eb