### PR TITLE
Implement dash afterimage effect

### DIFF
--- a/src/managers/ai-managers.js
+++ b/src/managers/ai-managers.js
@@ -155,19 +155,28 @@ export class MetaAIManager {
                 weapon.weaponStats.setCooldown(skillData.cooldown);
                 break; }
             case 'charge_attack': {
-                const { eventManager: ev } = context;
+                const { motionManager, eventManager: ev, enemies, vfxManager, assets } = context;
                 const { target, skill } = action;
-                ev.publish('vfx_request', {
-                    type: 'dash_trail',
-                    from: { x: entity.x, y: entity.y },
-                    to: { x: target.x, y: target.y }
-                });
-                const dx = target.x - entity.x;
-                const dy = target.y - entity.y;
-                const dist = Math.hypot(dx, dy) || 1;
-                entity.x = target.x - (dx / dist) * entity.width;
-                entity.y = target.y - (dy / dist) * entity.height;
-                ev.publish('entity_attack', { attacker: entity, defender: target, skill });
+
+                if (motionManager) {
+                    motionManager.dashTowards(
+                        entity,
+                        target,
+                        Math.floor(skill.chargeRange / context.mapManager.tileSize),
+                        enemies,
+                        ev,
+                        vfxManager,
+                        assets['strike-effect']
+                    );
+                } else {
+                    const dx = target.x - entity.x;
+                    const dy = target.y - entity.y;
+                    const dist = Math.hypot(dx, dy) || 1;
+                    entity.x = target.x - (dx / dist) * entity.width;
+                    entity.y = target.y - (dy / dist) * entity.height;
+                    ev.publish('entity_attack', { attacker: entity, defender: target, skill });
+                }
+
                 entity.mp -= skill.manaCost;
                 entity.skillCooldowns[skill.id] = skill.cooldown;
                 entity.attackCooldown = Math.max(1, Math.round(60 / (entity.attackSpeed || 1)));

--- a/src/managers/motionManager.js
+++ b/src/managers/motionManager.js
@@ -24,8 +24,27 @@ export class MotionManager {
         const destX = dest.x * tileSize;
         const destY = dest.y * tileSize;
 
+        if (destX === startPos.x && destY === startPos.y) return;
+
+        // 잔상과 기본 대쉬 궤적 효과
         if (vfxManager) {
             vfxManager.createDashTrail(startPos.x, startPos.y, destX, destY);
+
+            const steps = Math.max(6, actualMoveDistance * 3);
+            for (let i = 1; i <= steps; i++) {
+                const progress = i / steps;
+                const afterX = startPos.x + (destX - startPos.x) * progress;
+                const afterY = startPos.y + (destY - startPos.y) * progress;
+
+                vfxManager.addSpriteEffect(entity.image, afterX + entity.width / 2, afterY + entity.height / 2, {
+                    width: entity.width,
+                    height: entity.height,
+                    duration: 12,
+                    alpha: 0.35,
+                    fade: 0.04,
+                    blendMode: 'lighter'
+                });
+            }
         }
 
         const hitEnemies = new Set();


### PR DESCRIPTION
## Summary
- add afterimage particles along dash path in `MotionManager.dashTowards`
- use the new dash behavior for `charge_attack` actions
- enhance dash visuals with trails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856bce4ee608327972913fb2126f687