### PR TITLE
Make aquarium safer for testing

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -327,7 +327,8 @@ export class Game {
 
         // === 3. 몬스터 생성 ===
         const monsters = [];
-        for (let i = 0; i < 40; i++) {
+        const baseMonsterCount = this.mapManager.name === 'aquarium' ? 10 : 40;
+        for (let i = 0; i < baseMonsterCount; i++) {
             const pos = this.mapManager.getRandomFloorPosition();
             if (pos) {
                 let stats = {};

--- a/src/utils/aquariumUtils.js
+++ b/src/utils/aquariumUtils.js
@@ -23,7 +23,12 @@ export function adjustMonsterStatsForAquarium(baseStats = {}) {
     // Double the final value while keeping other bonuses intact.
     const originalHp = 10 + endurance * 5;
     const targetHp = originalHp * 2;
+
     adjusted.endurance = (targetHp - 10) / 5;
+
+    // Restrict monster vision so they remain idle when far from the player
+    const defaultVision = 192 * 2; // keep aquarium encounters manageable
+    adjusted.visionRange = Math.min(baseStats.visionRange ?? 192 * 4, defaultVision);
 
     return adjusted;
 }

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -140,4 +140,13 @@ test('RangedAI - follows player when no line of sight to enemy', () => {
     assert.deepStrictEqual(action.target, { x: 1, y: 2 });
 });
 
+test('MeleeAI - idle when enemy beyond vision range', () => {
+    const ai = new MeleeAI();
+    const self = { x: 0, y: 0, visionRange: 30, attackRange: 10, speed: 5, tileSize: 1 };
+    const enemy = { x: 100, y: 0 };
+    const context = { player: {}, allies: [], enemies: [enemy], mapManager: mapStub };
+    const action = ai.decideAction(self, context);
+    assert.strictEqual(action.type, 'idle');
+});
+
 });


### PR DESCRIPTION
## Summary
- restrict monster vision in Aquarium to keep them idle at range
- spawn fewer monsters on Aquarium maps
- cover idle behavior with new AI test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856bde3f6b08327bab80fad1366f5e0