### PR TITLE
Implement AI MBTI vfx events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,12 @@ const context = {
 HealerAI의 decideAction 메서드는 회복 대상을 찾을 때, 힐러 자신의 mbti 속성을 확인합니다.
 if (self.properties.mbti.includes('I')): 자신을 먼저 치유 대상으로 고려합니다.
 else if (self.properties.mbti.includes('E')): 자신을 포함한 모든 아군 중 가장 위급한 대상을 먼저 고려합니다.
+
+### 4.3. MBTI 팝업 이벤트 분리
+AI 로직은 더 이상 직접 MBTI 텍스트 팝업을 생성하지 않습니다. 대신
+`ai_mbti_trait_triggered` 이벤트를 발행하여 게임(`game.js`)이 이를 받아
+`VFXManager.addTextPopup`으로 시각 효과를 표시합니다. 이 방식은 VFX 처리와
+AI 판단 과정을 분리해 테스트와 유지 보수를 용이하게 합니다.
 5. 테스트 및 디버깅
 AI 로직은 두 가지 방식으로 테스트하고 확인할 수 있습니다.
 

--- a/VFX_GUIDE.md
+++ b/VFX_GUIDE.md
@@ -42,3 +42,9 @@
 ## 신규 효과: Bubble Emitter
 - `AquariumManager`의 `bubble` 피처가 호출되면 맵의 임의 위치에 거품 파티클 이미터가 생성됩니다.
 - 해당 이미터는 `spawnRate`를 조절해 지속적으로 파티클을 분출하며, `gravity` 값을 음수로 주어 위로 떠오르는 움직임을 연출합니다.
+
+## MBTI 텍스트 팝업 처리
+AI가 성격(MBTI) 특성을 발동하면 `ai_mbti_trait_triggered` 이벤트가 발생합니다.
+`Game` 클래스는 이를 구독해 `VFXManager.addTextPopup()`을 호출하며, 실제
+시각 효과는 이곳에서 생성됩니다. AI 로직에서는 이벤트만 발행하므로 팝업 표시
+동작을 손쉽게 조정할 수 있습니다.

--- a/src/ai.js
+++ b/src/ai.js
@@ -3,15 +3,8 @@
 import { hasLineOfSight } from './utils/geometry.js';
 import { SKILLS } from './data/skills.js';
 
-// Utility to show MBTI text popups above a unit
-function showMBTIPopup(eventManager, char, self) {
-    if (!eventManager || !char) return;
-    eventManager.publish('vfx_request', {
-        type: 'text_popup',
-        text: char,
-        target: self,
-    });
-}
+// AI 내에서 직접 팝업을 호출하지 않고 이벤트만 발생시켜
+// 시각 효과 로직과 분리한다.  실제 팝업 처리는 game.js가 담당한다.
 
 // --- AI 유형(Archetype)의 기반이 될 부모 클래스 ---
 class AIArchetype {
@@ -109,7 +102,7 @@ export class MeleeAI extends AIArchetype {
         if (mbti.includes('T')) {
             potentialTargets.sort((a, b) => a.hp - b.hp);
             if (potentialTargets.length > 0) {
-                showMBTIPopup(eventManager, 'T', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'T' });
             }
         } else if (mbti.includes('F')) {
             const allyTargets = new Set();
@@ -119,7 +112,7 @@ export class MeleeAI extends AIArchetype {
             const focusedTarget = potentialTargets.find(t => allyTargets.has(t.id));
             if (focusedTarget) {
                 potentialTargets = [focusedTarget];
-                showMBTIPopup(eventManager, 'F', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'F' });
             }
         }
 
@@ -156,7 +149,7 @@ export class MeleeAI extends AIArchetype {
                 ? self.skills.map(id => SKILLS[id]).find(s => s && s.tags && s.tags.includes('charge'))
                 : null;
             if (mbti.includes('P')) {
-                showMBTIPopup(eventManager, 'P', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'P' });
             }
 
             if (
@@ -180,9 +173,9 @@ export class MeleeAI extends AIArchetype {
                     (self.skillCooldowns[skillId] || 0) <= 0
                 ) {
                     if (mbti.includes('S')) {
-                        showMBTIPopup(eventManager, 'S', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'S' });
                     } else if (mbti.includes('N') && self.hp / self.maxHp < 0.6) {
-                        showMBTIPopup(eventManager, 'N', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'N' });
                     }
                     return { type: 'skill', target: nearestTarget, skillId };
                 }
@@ -238,7 +231,7 @@ export class HealerAI extends AIArchetype {
                 let targetCandidate = null;
                 if (mbti.includes('T')) {
                     targetCandidate = potential.reduce((low, cur) => cur.hp < low.hp ? cur : low, potential[0]);
-                    showMBTIPopup(eventManager, 'T', self);
+                    eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'T' });
                 } else if (mbti.includes('F')) {
                     const allyTargets = new Set();
                     allies.forEach(a => {
@@ -247,7 +240,7 @@ export class HealerAI extends AIArchetype {
                     const focused = potential.find(t => allyTargets.has(t.id));
                     if (focused) {
                         targetCandidate = focused;
-                        showMBTIPopup(eventManager, 'F', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'F' });
                     }
                 }
                 const nearest = targetCandidate || potential.reduce(
@@ -313,16 +306,16 @@ export class HealerAI extends AIArchetype {
 
         if (distance <= self.attackRange && hasLOS && skillReady) {
             if (mbti.includes('S')) {
-                showMBTIPopup(eventManager, 'S', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'S' });
             } else if (mbti.includes('N')) {
-                showMBTIPopup(eventManager, 'N', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'N' });
             }
 
             // E/I 성향을 실제 힐 순간에 표시
             if (mbti.includes('E')) {
-                showMBTIPopup(eventManager, 'E', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'E' });
             } else if (mbti.includes('I')) {
-                showMBTIPopup(eventManager, 'I', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'I' });
             }
 
             return { type: 'skill', target, skillId: healId };
@@ -416,7 +409,7 @@ export class RangedAI extends AIArchetype {
         if (mbti.includes('T')) {
             potentialTargets.sort((a, b) => a.hp - b.hp);
             if (potentialTargets.length > 0) {
-                showMBTIPopup(eventManager, 'T', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'T' });
             }
         } else if (mbti.includes('F')) {
             const allyTargets = new Set();
@@ -426,7 +419,7 @@ export class RangedAI extends AIArchetype {
             const focusedTarget = potentialTargets.find(t => allyTargets.has(t.id));
             if (focusedTarget) {
                 potentialTargets = [focusedTarget];
-                showMBTIPopup(eventManager, 'F', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'F' });
             }
         }
 
@@ -461,9 +454,9 @@ export class RangedAI extends AIArchetype {
                 if (minDistance <= self.attackRange && minDistance > self.attackRange * 0.5) {
                     // S/N 성향에 따른 스킬 사용 시점 표시
                     if (mbti.includes('S')) {
-                        showMBTIPopup(eventManager, 'S', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'S' });
                     } else if (mbti.includes('N') && self.hp / self.maxHp < 0.6) {
-                        showMBTIPopup(eventManager, 'N', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'N' });
                     }
 
                     const skillId = self.skills && self.skills[0];
@@ -481,11 +474,11 @@ export class RangedAI extends AIArchetype {
                 if (minDistance <= self.attackRange * 0.5) {
                     // P 성향은 후퇴하지 않고 돌격
                     if (mbti.includes('P')) {
-                        showMBTIPopup(eventManager, 'P', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'P' });
                         return { type: 'move', target: nearestTarget };
                     }
                     if (mbti.includes('J')) {
-                        showMBTIPopup(eventManager, 'J', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'J' });
                     }
                     const dx = nearestTarget.x - self.x;
                     const dy = nearestTarget.y - self.y;
@@ -831,9 +824,9 @@ export class BardAI extends AIArchetype {
                 if (distance <= self.attackRange) {
                     // E/I 성향을 실제 노래 시점에 표시
                     if (mbti.includes('E')) {
-                        showMBTIPopup(eventManager, 'E', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'E' });
                     } else if (mbti.includes('I')) {
-                        showMBTIPopup(eventManager, 'I', self);
+                        eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'I' });
                     }
                     return { type: 'skill', target, skillId };
                 }
@@ -847,7 +840,7 @@ export class BardAI extends AIArchetype {
             let targetCandidate = null;
             if (mbti.includes('T')) {
                 targetCandidate = potential.reduce((low, cur) => cur.hp < low.hp ? cur : low, potential[0]);
-                showMBTIPopup(eventManager, 'T', self);
+                eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'T' });
             } else if (mbti.includes('F')) {
                 const allyTargets = new Set();
                 allies.forEach(a => {
@@ -856,7 +849,7 @@ export class BardAI extends AIArchetype {
                 const focused = potential.find(t => allyTargets.has(t.id));
                 if (focused) {
                     targetCandidate = focused;
-                    showMBTIPopup(eventManager, 'F', self);
+                    eventManager?.publish('ai_mbti_trait_triggered', { entity: self, trait: 'F' });
                 }
             }
             const nearest = targetCandidate || potential.reduce(

--- a/src/game.js
+++ b/src/game.js
@@ -927,6 +927,13 @@ export class Game {
             }
         });
 
+        // AI가 성격 특성을 발동했을 때 텍스트 팝업으로 표시
+        eventManager.subscribe('ai_mbti_trait_triggered', (data) => {
+            if (this.vfxManager) {
+                this.vfxManager.addTextPopup(data.trait, data.entity);
+            }
+        });
+
         // 스탯 변경 이벤트 구독 (효과 적용/해제 시 스탯 재계산)
         eventManager.subscribe('stats_changed', (data) => {
             data.entity.stats.recalculate();


### PR DESCRIPTION
## Summary
- decouple MBTI popups from AI logic
- notify the game when an AI trait triggers via `ai_mbti_trait_triggered`
- handle the new event in `game.js` and show text popups
- document the MBTI popup event in the AI and VFX guides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856c6054318832799bd037697adfcd3