### PR TITLE
Implement alphabet state effects

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -55,3 +55,8 @@
 ## 세션 12
 - 아티팩트 아이템 시스템 초안 구현. `healing_talisman` 샘플을 추가하고 쿨다운이 돌아가도록 엔티티와 ItemAIManager를 수정.
 - 새 테스트 `artifact.test.js`에서 아티팩트 사용 및 쿨다운 갱신을 검증.
+
+## 세션 13
+- 알파벳 상태 효과 8종을 `effects.js`에 추가.
+- `StatManager`가 상태 효과를 감지해 스탯 보너스를 적용하도록 수정.
+- 새 테스트 `alphabetState.test.js`로 이동 속도 증가를 확인.

--- a/src/data/effects.js
+++ b/src/data/effects.js
@@ -253,5 +253,63 @@ export const EFFECTS = {
         duration: 600,
         tags: ['status_ailment', 'cc', 'charm', 'ai_override'],
         particle: { type: 'heart', color: 'rgba(255, 105, 180, 0.9)' }
+    },
+
+    // --- 알파벳 상태 효과 (Emotion Card 기반) ---
+    state_E: {
+        name: 'E 상태',
+        type: 'state',
+        duration: 300,
+        tags: ['alphabet_state', 'E_state'],
+        stats: { agility: 1 }
+    },
+    state_I: {
+        name: 'I 상태',
+        type: 'state',
+        duration: 300,
+        tags: ['alphabet_state', 'I_state'],
+        stats: { strength: 1 }
+    },
+    state_S: {
+        name: 'S 상태',
+        type: 'state',
+        duration: 300,
+        tags: ['alphabet_state', 'S_state'],
+        stats: { attackSpeed: 0.1 }
+    },
+    state_N: {
+        name: 'N 상태',
+        type: 'state',
+        duration: 300,
+        tags: ['alphabet_state', 'N_state'],
+        stats: { intelligence: 1 }
+    },
+    state_T: {
+        name: 'T 상태',
+        type: 'state',
+        duration: 300,
+        tags: ['alphabet_state', 'T_state'],
+        stats: { attackSpeed: 0.1 }
+    },
+    state_F: {
+        name: 'F 상태',
+        type: 'state',
+        duration: 300,
+        tags: ['alphabet_state', 'F_state'],
+        stats: { hpRegen: 0.05 }
+    },
+    state_P: {
+        name: 'P 상태',
+        type: 'state',
+        duration: 300,
+        tags: ['alphabet_state', 'P_state'],
+        stats: { movement: 1 }
+    },
+    state_J: {
+        name: 'J 상태',
+        type: 'state',
+        duration: 300,
+        tags: ['alphabet_state', 'J_state'],
+        stats: { movement: -1 }
     }
 };

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,5 +1,16 @@
 // src/stats.js
 
+const STATE_BONUSES = {
+    state_E: { agility: 1 },
+    state_I: { strength: 1 },
+    state_S: { attackSpeed: 0.1 },
+    state_N: { intelligence: 1 },
+    state_T: { attackSpeed: 0.1 },
+    state_F: { hpRegen: 0.05 },
+    state_P: { movement: 1 },
+    state_J: { movement: -1 },
+};
+
 export class StatManager {
     constructor(entity, config = {}) {
         // entity 자신을 참조할 수 있도록 저장
@@ -108,6 +119,17 @@ export class StatManager {
         for (const stat in this._fromEquipment) {
             if (!(stat in final)) {
                 final[stat] = this._fromEquipment[stat];
+            }
+        }
+
+        if (this.entity && Array.isArray(this.entity.effects)) {
+            for (const effect of this.entity.effects) {
+                const bonus = STATE_BONUSES[effect.id];
+                if (bonus) {
+                    for (const [stat, val] of Object.entries(bonus)) {
+                        final[stat] = (final[stat] || 0) + val;
+                    }
+                }
             }
         }
 

--- a/tests/alphabetState.test.js
+++ b/tests/alphabetState.test.js
@@ -1,0 +1,13 @@
+import { StatManager } from '../src/stats.js';
+import { EFFECTS } from '../src/data/effects.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('Alphabet State Effects', () => {
+    test('P 상태가 이동력을 증가시킨다', () => {
+        const entity = { effects: [] };
+        entity.stats = new StatManager(entity, { movement: 2 });
+        entity.effects.push({ id: 'state_P', ...EFFECTS.state_P, remaining: 100 });
+        entity.stats.recalculate();
+        assert.strictEqual(entity.stats.get('movement'), 3);
+    });
+});


### PR DESCRIPTION
## Summary
- add alphabet state effects for emotion card system
- apply bonuses in StatManager when states are active
- record session 13 progress in dev log
- cover new mechanic with alphabet state unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856c99930908327b27496a53a7980c5