### PR TITLE
Fix faith stat test and stabilize flow

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -32,6 +32,7 @@ export class CharacterFactory {
         }
         const originId = this._rollRandomKey(ORIGINS);
         let faithId = null;
+        // unit-features-plan.md에 따라 플레이어는 신앙을 갖지 않음
         if (type !== 'player') {
             faithId = this._rollRandomKey(FAITHS);
         }

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,4 +1,5 @@
 // src/stats.js
+import { FAITHS } from './data/faiths.js';
 
 const STATE_BONUSES = {
     state_E: { agility: 1 },
@@ -119,6 +120,14 @@ export class StatManager {
         for (const stat in this._fromEquipment) {
             if (!(stat in final)) {
                 final[stat] = this._fromEquipment[stat];
+            }
+        }
+
+        // 신앙 보너스 합산
+        const faithId = this.entity?.properties?.faith;
+        if (faithId && FAITHS[faithId] && FAITHS[faithId].statBonuses) {
+            for (const [stat, bonus] of Object.entries(FAITHS[faithId].statBonuses)) {
+                final[stat] = (final[stat] || 0) + bonus;
             }
         }
 

--- a/tests/faith.test.js
+++ b/tests/faith.test.js
@@ -1,26 +1,50 @@
 import { CharacterFactory } from '../src/factory.js';
 import { FAITHS } from '../src/data/faiths.js';
+import { StatManager } from '../src/stats.js';
 import { describe, test, assert } from './helpers.js';
 
 const assets = {};
 const faithKeys = Object.keys(FAITHS);
 
-describe('Faith assignment', () => {
-  test('player does not get faith', () => {
+describe('Faith System', () => {
+  test('플레이어는 신앙을 갖지 않는다', () => {
     const factory = new CharacterFactory(assets);
     const player = factory.create('player', { x:0, y:0, tileSize:1, groupId:'g' });
-    assert.ok(!player.properties.faith);
+    assert.ok(!player.properties.faith, 'Player should not have a faith.');
   });
 
-  test('mercenary gets valid faith', () => {
+  test('용병은 유효한 신앙을 부여받는다', () => {
     const factory = new CharacterFactory(assets);
     const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g' });
-    assert.ok(faithKeys.includes(merc.properties.faith));
+    assert.ok(merc.properties.faith, 'Mercenary should have a faith.');
+    assert.ok(faithKeys.includes(merc.properties.faith), 'Mercenary faith should be a valid key.');
   });
 
-  test('monster gets valid faith', () => {
+  test('몬스터는 유효한 신앙을 부여받는다', () => {
     const factory = new CharacterFactory(assets);
     const mon = factory.create('monster', { x:0, y:0, tileSize:1, groupId:'g' });
-    assert.ok(faithKeys.includes(mon.properties.faith));
+    assert.ok(mon.properties.faith, 'Monster should have a faith.');
+    assert.ok(faithKeys.includes(mon.properties.faith), 'Monster faith should be a valid key.');
+  });
+
+  test('신앙에 따른 스탯 보너스가 올바르게 적용된다', () => {
+    const factory = new CharacterFactory(assets);
+    const merc = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g' });
+
+    // 기본 신앙을 제거하고 스탯을 계산해 기준값을 얻는다
+    merc.properties.faith = null;
+    merc.stats.recalculate();
+    const baseAttack = merc.stats.get('attackPower');
+    const baseDefense = merc.stats.get('defense');
+
+    // 불의 신 신앙을 부여한 뒤 스탯을 다시 계산
+    merc.properties.faith = 'FIRE_GOD';
+    merc.stats.recalculate();
+    const newAttack = merc.stats.get('attackPower');
+    const newDefense = merc.stats.get('defense');
+
+    const bonus = FAITHS.FIRE_GOD.statBonuses;
+    assert.strictEqual(newAttack, baseAttack + bonus.attackPower, '불의 신 공격력 보너스가 적용되어야 합니다.');
+    assert.strictEqual(newDefense, (baseDefense || 0) + bonus.defense, '불의 신 방어력 패널티가 적용되어야 합니다.');
   });
 });

--- a/tests/microSmoke.test.js
+++ b/tests/microSmoke.test.js
@@ -38,8 +38,12 @@ test('간단한 게임 흐름', () => {
     assert.ok(expEvent, '경험치 이벤트 발생');
     assert.ok(merc.stats.get('exp') > 0, '용병 경험치 증가');
 
-    const weapon = itemFactory.create('short_sword', 0, 0, 1);
+    // 기존 장비를 제거한 후 더 강력한 무기를 장착하여 스탯 상승을 확인한다
+    merc.equipment.weapon = null;
+    merc.stats.updateEquipmentStats();
     const beforeAtk = merc.stats.get('attackPower');
+
+    const weapon = itemFactory.create('estoc', 0, 0, 1);
     merc.equipment.weapon = weapon;
     merc.stats.updateEquipmentStats();
     merc.updateAI();


### PR DESCRIPTION
## Summary
- adjust faith stat bonus test to remove randomness
- ensure smoke test removes default weapon before equipping better gear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856cd5110e08327aced2ac87b348fbc