### PR TITLE
Implement KnockbackEngine and docs update

### DIFF
--- a/VFX_GUIDE.md
+++ b/VFX_GUIDE.md
@@ -48,3 +48,6 @@ AI가 성격(MBTI) 특성을 발동하면 `ai_mbti_trait_triggered` 이벤트가
 `Game` 클래스는 이를 구독해 `VFXManager.addTextPopup()`을 호출하며, 실제
 시각 효과는 이곳에서 생성됩니다. AI 로직에서는 이벤트만 발행하므로 팝업 표시
 동작을 손쉽게 조정할 수 있습니다.
+
+## Knockback 연출 분리
+`KnockbackEngine`은 대상의 위치 이동을 직접 제어합니다. 넉백이 발생하면 이 엔진이 매 프레임 위치를 보정하고, `VFXManager`는 잔상이나 충격파 같은 시각 효과만 담당합니다. 물리 로직과 VFX가 분리되어 테스트와 유지 보수가 쉬워집니다.

--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -62,6 +62,7 @@
 | `turnManager.js` | 턴 기반 전투 모드에서 행동 순서를 결정하도록 설계되었습니다. |
 | `uiManager.js` | 인벤토리와 용병 패널 등 DOM 기반 UI 요소를 관리합니다. |
 | `vfxManager.js` | 파티클 및 스프라이트 효과를 생성하여 시각 연출을 담당합니다. |
+| `../engines/knockbackEngine.js` | 넉백 물리와 위치 보정을 전담하는 전용 엔진입니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |
 | `../micro/MicroTurnManager.js` | 모든 아이템의 쿨타임 감소를 전담합니다. |
 

--- a/src/combat.js
+++ b/src/combat.js
@@ -3,9 +3,10 @@
 import { WEAPON_SKILLS } from './data/weapon-skills.js';
 
 export class CombatCalculator {
-    constructor(eventManager, tagManager) {
+    constructor(eventManager, tagManager, knockbackEngine) {
         this.eventManager = eventManager;
         this.tagManager = tagManager;
+        this.knockbackEngine = knockbackEngine;
     }
 
     _calculateRuneDamage(weapon, skill) {
@@ -85,7 +86,13 @@ export class CombatCalculator {
             damageMultiplier = 1.5;
             attacker.effects = attacker.effects.filter(e => e.id !== 'charging_shot_effect');
             this.eventManager.publish('log', { message: `[충전된 사격]이 발동됩니다!`, color: 'magenta' });
-            this.eventManager.publish('knockback_request', { attacker, defender, distance: 128 });
+            // KnockbackEngine과의 호환을 위해 이벤트를 발행합니다
+            this.eventManager.publish('knockback_request', {
+                defender,
+                attacker,
+                distance: 128,
+                duration: 15,
+            });
         }
 
         if (skill && skill.id === 'backstab' && this._isBehind(attacker, defender)) {

--- a/src/engine.js
+++ b/src/engine.js
@@ -35,6 +35,9 @@ export class Engine {
         const { player } = this.gameState;
         const { monsterManager, mercenaryManager, petManager, itemManager, metaAIManager, fogManager } = this.managers;
 
+        // --- KnockbackEngine 업데이트 루프 추가 ---
+        this.managers.knockbackEngine.update();
+
         // Player movement
         let moveX = 0, moveY = 0;
         if (this.inputHandler.keysPressed['ArrowUp']) moveY -= player.speed;
@@ -85,7 +88,7 @@ export class Engine {
 
         Object.entries(this.managers).forEach(([name, manager]) => {
             if (typeof manager.update === 'function') {
-                if (name === 'fogManager') return; // 시야 매니저는 별도 처리
+                if (name === 'fogManager' || manager === this.managers.knockbackEngine) return; // 시야 매니저와 넉백 엔진은 별도 처리
                 if (['metaAIManager', 'itemAIManager', 'possessionAIManager'].includes(name)) {
                     manager.update(context);
                 } else {

--- a/src/engines/knockbackEngine.js
+++ b/src/engines/knockbackEngine.js
@@ -1,0 +1,96 @@
+export class KnockbackEngine {
+    constructor(eventManager, mapManager, vfxManager) {
+        this.eventManager = eventManager;
+        this.mapManager = mapManager;
+        this.vfxManager = vfxManager;
+        this.activeKnockbacks = []; // 현재 처리 중인 넉백 작업 목록
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('knockback_request', data => {
+                const { defender, attacker, distance, duration } = data;
+                this.requestKnockback(defender, attacker, distance, duration);
+            });
+        }
+
+        console.log('[KnockbackEngine] Initialized');
+    }
+
+    /**
+     * 넉백을 요청받아 작업 큐에 추가합니다.
+     * @param {object} defender - 넉백될 대상
+     * @param {object} attacker - 넉백 유발자
+     * @param {number} distance - 넉백 거리 (픽셀)
+     * @param {number} duration - 넉백 지속 시간 (프레임)
+     */
+    requestKnockback(defender, attacker, distance, duration = 15) {
+        const resistance = defender.stats.get('movementResist') || 0;
+        if (Math.random() < resistance) {
+            this.eventManager.publish('log', { message: `\uD83D\uDEE1\uFE0F ${defender.constructor.name}\uC774(\uAC00) \uB108\uD06C\uBC31\uC5D0 \uC800\uD56D\uD588\uC2B5\uB2C8\uB2E4!`, color: 'cyan' });
+            return;
+        }
+
+        const fromPos = { x: defender.x, y: defender.y };
+        const angle = Math.atan2(defender.y - attacker.y, defender.x - attacker.x);
+        let toPos = {
+            x: defender.x + Math.cos(angle) * distance,
+            y: defender.y + Math.sin(angle) * distance
+        };
+        let hitWall = false;
+
+        if (this.mapManager.isWallAt(toPos.x, toPos.y, defender.width, defender.height)) {
+            hitWall = true;
+            toPos = {
+                x: defender.x + Math.cos(angle) * (distance / 2),
+                y: defender.y + Math.sin(angle) * (distance / 2)
+            };
+        }
+
+        this.activeKnockbacks.push({
+            defender,
+            fromPos,
+            toPos,
+            duration,
+            life: duration,
+            hitWall,
+            attacker,
+        });
+
+        this.eventManager.publish('log', { message: `\uD83D\uDCA8 ${defender.constructor.name}\uC774(\uAC00) \uB108\uD06C\uBC31\uB429\uB2C8\uB2E4!`, color: 'lightblue' });
+    }
+
+    /**
+     * 매 \uD504\uB808\uC784 \uC2E4\uD589\uB418\uBA70 \uBAA8\uB4E0 \uB108\uD06C\uBC31 \uC0C1\uD0DC\uB97C \uC5C5\uB370\uC774\uD2B8\uD569\uB2C8\uB2E4.
+     */
+    update() {
+        if (this.activeKnockbacks.length === 0) return;
+
+        for (let i = this.activeKnockbacks.length - 1; i >= 0; i--) {
+            const job = this.activeKnockbacks[i];
+            job.life--;
+
+            const progress = 1 - (job.life / job.duration);
+
+            job.defender.x = job.fromPos.x + (job.toPos.x - job.fromPos.x) * progress;
+            job.defender.y = job.fromPos.y + (job.toPos.y - job.fromPos.y) * progress;
+
+            if (this.vfxManager && job.life % 2 === 0) {
+                this.vfxManager.addSpriteEffect(job.defender.image, job.defender.x, job.defender.y, {
+                    width: job.defender.width,
+                    height: job.defender.height,
+                    duration: 8, alpha: 0.4, fade: 0.05, blendMode: 'lighter'
+                });
+            }
+
+            if (job.life <= 0) {
+                job.defender.x = job.toPos.x;
+                job.defender.y = job.toPos.y;
+
+                if (job.hitWall) {
+                    this.eventManager.publish('knockback_wall_impact', { defender: job.defender, attacker: job.attacker });
+                }
+
+                this.activeKnockbacks.splice(i, 1);
+            }
+        }
+    }
+}

--- a/src/managers/vfxManager.js
+++ b/src/managers/vfxManager.js
@@ -35,24 +35,6 @@ export class VFXManager {
         this.effects.push(effect);
     }
 
-    /**
-     * 대상을 뒤로 밀어내는 넉백 애니메이션을 추가합니다.
-     * @param {Entity} targetEntity - 밀려날 유닛
-     * @param {{x:number, y:number}} fromPos - 시작 위치
-     * @param {{x:number, y:number}} toPos - 도착 위치
-     * @param {number} [duration=15] - 애니메이션 지속 시간 (프레임)
-     */
-    addKnockbackAnimation(targetEntity, fromPos, toPos, duration = 15) {
-        const effect = {
-            type: 'knockback_animation',
-            targetEntity,
-            fromPos,
-            toPos,
-            duration,
-            life: duration,
-        };
-        this.effects.push(effect);
-    }
 
     /**
      * 화면에 퍼져나가는 충격파 효과를 추가합니다.
@@ -587,22 +569,6 @@ export class VFXManager {
                 continue;
             }
 
-            if (effect.type === 'knockback_animation') {
-                effect.life--;
-                const progress = 1 - (effect.life / effect.duration);
-
-                const newX = effect.fromPos.x + (effect.toPos.x - effect.fromPos.x) * progress;
-                const newY = effect.fromPos.y + (effect.toPos.y - effect.fromPos.y) * progress;
-                effect.targetEntity.x = newX;
-                effect.targetEntity.y = newY;
-
-                if (effect.life <= 0) {
-                    effect.targetEntity.x = effect.toPos.x;
-                    effect.targetEntity.y = effect.toPos.y;
-                    this.effects.splice(i, 1);
-                }
-                continue;
-            }
 
         if (effect.type === 'item_use') {
             effect.life--;

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -1,6 +1,7 @@
 import * as Managers from '../managers/index.js';
 import { TagManager } from '../managers/tagManager.js';
 import { CombatCalculator } from '../combat.js';
+import { KnockbackEngine } from '../engines/knockbackEngine.js';
 import { PathfindingManager } from '../managers/pathfindingManager.js';
 import { MovementManager } from '../managers/movementManager.js';
 import { FogManager } from '../managers/fogManager.js';
@@ -18,8 +19,12 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.mapManager = mapManager;
 
     // 기본 관리자
+    managers.vfxManager = new Managers.VFXManager(eventManager, null);
+
+    // --- KnockbackEngine을 생성하고 CombatCalculator에 주입 ---
+    managers.knockbackEngine = new KnockbackEngine(eventManager, mapManager, managers.vfxManager);
     managers.tagManager = new TagManager();
-    managers.combatCalculator = new CombatCalculator(eventManager, managers.tagManager);
+    managers.combatCalculator = new CombatCalculator(eventManager, managers.tagManager, managers.knockbackEngine);
 
     // 월드 관련
     managers.pathfindingManager = new PathfindingManager(mapManager);
@@ -39,6 +44,7 @@ export function createManagers(eventManager, assets, factory, mapManager) {
 
     // 시각 및 효과
     managers.vfxManager = new Managers.VFXManager(eventManager, managers.itemManager);
+    managers.vfxManager.itemManager = managers.itemManager;
     managers.effectManager = new Managers.EffectManager(eventManager, managers.vfxManager);
     managers.effectIconManager = new Managers.EffectIconManager(eventManager, assets);
 


### PR DESCRIPTION
## Summary
- document separation of knockback visuals from VFXManager
- list `knockbackEngine` in manager overview docs
- add new KnockbackEngine engine and integrate it with combat calculator
- call KnockbackEngine from the main engine update loop
- remove old knockback animation handling from VFXManager
- expose KnockbackEngine through manager registry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856dc9885d483279230fb8d7b3787b8