### PR TITLE
Fix initialization errors for hire and status icons

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -7,6 +7,7 @@ import { InputHandler } from './inputHandler.js';
 import { createManagers } from './setup/managerRegistry.js';
 import { buildInitialWorld } from './setup/worldBuilder.js';
 import { registerGameEventListeners } from './setup/eventListeners.js';
+import { EFFECTS } from './data/effects.js';
 
 export class Engine {
     constructor(assets) {
@@ -133,7 +134,11 @@ export class Engine {
         this.managers.projectileManager.render(this.layerManager.contexts.vfx);
         this.managers.speechBubbleManager.render(this.layerManager.contexts.vfx);
         this.managers.uiManager.renderHpBars(this.layerManager.contexts.vfx, player, this.managers.monsterManager.monsters, this.managers.mercenaryManager.mercenaries);
-        this.managers.effectIconManager.render(this.layerManager.contexts.vfx, [player, ...this.managers.monsterManager.monsters, ...this.managers.mercenaryManager.mercenaries], this.managers.effectManager.effectsData);
+        this.managers.effectIconManager.render(
+            this.layerManager.contexts.vfx,
+            [player, ...this.managers.monsterManager.monsters, ...this.managers.mercenaryManager.mercenaries],
+            EFFECTS
+        );
         this.managers.fogManager.render(this.layerManager.contexts.weather, this.mapManager.tileSize);
 
         Object.values(this.layerManager.contexts).forEach(ctx => ctx.restore());

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -14,6 +14,7 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     const managers = {};
 
     // 외부에서 전달된 기본 도구 보존
+    managers.eventManager = eventManager;
     managers.factory = factory;
     managers.mapManager = mapManager;
 


### PR DESCRIPTION
## Summary
- expose `eventManager` in the manager registry so worldBuilder can publish events
- use `EFFECTS` data directly when rendering status icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e21016e08327885ff3215af42f72