### PR TITLE
Implement tactical playbook with role updates

### DIFF
--- a/src/data/aiPlaybook.js
+++ b/src/data/aiPlaybook.js
@@ -1,0 +1,144 @@
+// AI Tactics Playbook
+
+// Tactical behavior helpers
+const TACTICAL_ACTIONS = {
+    ENGAGE_AND_HOLD: (entity, target) => {
+        const distance = Math.hypot(target.x - entity.x, target.y - entity.y);
+        if (distance < (entity.attackRange || 1)) {
+            return { type: 'attack', target };
+        }
+        return { type: 'move', target };
+    },
+    FLANK: (entity, target, direction = 'left') => {
+        const offsetAngle = direction === 'left' ? -Math.PI / 2 : Math.PI / 2;
+        const targetAngle = Math.atan2(target.y - entity.y, target.x - entity.x);
+        const finalAngle = targetAngle + offsetAngle;
+        const flankPos = {
+            x: target.x + Math.cos(finalAngle) * 100,
+            y: target.y + Math.sin(finalAngle) * 100,
+        };
+        const dist = Math.hypot(flankPos.x - entity.x, flankPos.y - entity.y);
+        if (dist < (entity.attackRange || 1)) {
+            return { type: 'attack', target };
+        }
+        return { type: 'move', target: flankPos };
+    },
+    PURSUE: (entity, target) => ({ type: 'move', target }),
+    ATTACK: (entity, target) => ({ type: 'attack', target }),
+    IDLE: () => ({ type: 'idle' })
+};
+
+export const AI_PLAYBOOK = {
+    // Hammer and Anvil tactic
+    hammer_and_anvil: {
+        name: '망치와 모루',
+        condition: (ctx) => {
+            const anvils = ctx.allies.filter(a => a.equipment?.off_hand?.tags?.includes('shield'));
+            const hammers = ctx.allies.filter(a => !a.equipment?.off_hand?.tags?.includes('shield'));
+            return anvils.length >= 1 && hammers.length >= 1 && ctx.enemies.length <= 3;
+        },
+        score: (ctx) => 150 / (ctx.enemies.length || 1),
+        roles: [
+            {
+                name: 'anvil',
+                count: 1,
+                selector: (ctx) => ctx.allies.sort((a,b) => (b.stats?.get('defense') || 0) - (a.stats?.get('defense') || 0))[0],
+                action: (self, roles) => TACTICAL_ACTIONS.ENGAGE_AND_HOLD(self, roles.target[0])
+            },
+            {
+                name: 'hammer',
+                count: 1,
+                selector: (ctx, assigned) => ctx.allies.filter(a => a !== assigned.anvil?.[0]).sort((a,b) => (b.stats?.get('attackPower') || 0) - (a.stats?.get('attackPower') || 0))[0],
+                action: (self, roles) => TACTICAL_ACTIONS.FLANK(self, roles.target[0], 'left')
+            },
+            {
+                name: 'target',
+                count: 1,
+                selector: (ctx, assigned) => ctx.enemies.sort((a,b) => Math.hypot(a.x - assigned.anvil[0].x, a.y - assigned.anvil[0].y) - Math.hypot(b.x - assigned.anvil[0].x, b.y - assigned.anvil[0].y))[0]
+            }
+        ],
+        duration: 400
+    },
+
+    // Pincer Attack
+    pincer_attack: {
+        name: '포위 섬멸',
+        condition: (ctx) => {
+            const meleeAllies = ctx.allies.filter(a => !a.equipment?.weapon?.tags?.includes('ranged'));
+            return meleeAllies.length >= 2 && ctx.enemies.length === 1;
+        },
+        score: (ctx) => 100 - ctx.enemies[0].hp,
+        roles: [
+            { name: 'flanker_left', count: 1, action: (self, roles) => TACTICAL_ACTIONS.FLANK(self, roles.target[0], 'left') },
+            { name: 'flanker_right', count: 1, action: (self, roles) => TACTICAL_ACTIONS.FLANK(self, roles.target[0], 'right') },
+            { name: 'target', count: 1, selector: (ctx) => ctx.enemies[0] }
+        ],
+        duration: 300
+    },
+
+    // Focus Fire Weakest
+    focus_fire_weakest: {
+        name: '최약체 집중 공격',
+        condition: (ctx) => ctx.allies.length >= 2 && ctx.enemies.length >= 2,
+        score: () => 80,
+        roles: [
+            { name: 'attackers', count: 'all', action: (self, roles) => TACTICAL_ACTIONS.ATTACK(self, roles.target[0]) },
+            { name: 'target', count: 1, selector: (ctx) => ctx.enemies.slice().sort((a,b) => a.hp - b.hp)[0] }
+        ],
+        duration: 240
+    },
+
+    // Feigned Retreat (multi-stage)
+    feigned_retreat: {
+        name: '유인책',
+        condition: (ctx) => ctx.allies.length >= 3 && ctx.enemies.length === 1,
+        score: () => 90,
+        roles: [
+            {
+                name: 'bait',
+                count: 1,
+                selector: (ctx) => ctx.allies.slice().sort((a,b) => (b.stats?.get('movementSpeed')||0) - (a.stats?.get('movementSpeed')||0))[0],
+                action: (self, roles, tactic) => {
+                    const player = roles.lure_target[0];
+                    const ambush = roles.ambush_point[0];
+                    const d = Math.hypot(player.x - self.x, player.y - self.y);
+                    if (tactic.stage === 'luring' && d < 300) {
+                        tactic.stage = 'retreating';
+                    }
+                    if (tactic.stage === 'retreating') {
+                        return TACTICAL_ACTIONS.PURSUE(self, ambush);
+                    }
+                    return TACTICAL_ACTIONS.PURSUE(self, player);
+                }
+            },
+            {
+                name: 'ambushers',
+                count: 'all',
+                action: (self, roles, tactic) => {
+                    const player = roles.lure_target[0];
+                    const d = Math.hypot(player.x - self.x, player.y - self.y);
+                    if (d < 250) {
+                        tactic.stage = 'attack';
+                    }
+                    if (tactic.stage === 'attack') {
+                        return TACTICAL_ACTIONS.ATTACK(self, player);
+                    }
+                    return TACTICAL_ACTIONS.IDLE();
+                }
+            },
+            { name: 'lure_target', count: 1, selector: (ctx) => ctx.enemies[0] },
+            { name: 'ambush_point', count: 1, selector: (ctx, assigned) => ctx.allies.find(a => a.id !== assigned.bait[0].id) }
+        ],
+        duration: 1200,
+        update: (tactic, ctx) => {
+            if (tactic.stage === 'initial') {
+                tactic.stage = 'luring';
+                const bait = tactic.roles.bait[0];
+                const player = tactic.roles.lure_target[0];
+                const ambushX = bait.x + (bait.x - player.x);
+                const ambushY = bait.y + (bait.y - player.y);
+                tactic.roles.ambush_point[0] = { x: ambushX, y: ambushY };
+            }
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add dynamic role reassignment for active tactics in AI engine
- randomize tactic selection when scores tie
- ensure assigned roles stay valid during combat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856e3cb86b48327bf69f91140b991f9