### PR TITLE
Fix crash when attacker undefined

### DIFF
--- a/src/micro/MicroCombatManager.js
+++ b/src/micro/MicroCombatManager.js
@@ -7,6 +7,7 @@ export class MicroCombatManager {
     }
 
     resolveAttack(attacker, defender) {
+        if (!attacker || !defender) return;
         const weapon = attacker.equipment?.weapon;
         const armor = defender.equipment?.armor;
         if (!weapon || !armor) return;

--- a/src/setup/eventListeners.js
+++ b/src/setup/eventListeners.js
@@ -9,6 +9,7 @@ export function registerGameEventListeners(engine) {
     const { combatCalculator, vfxManager, effectManager, monsterManager, itemManager, uiManager, motionManager, equipmentManager, projectileManager } = managers;
 
     eventManager.subscribe('entity_attack', (data) => {
+        if (!data.attacker || !data.defender) return;
         managers.microCombatManager.resolveAttack(data.attacker, data.defender);
         combatCalculator.handleAttack(data);
         if (!data.skill || !data.skill.projectile) {


### PR DESCRIPTION
## Summary
- guard against missing entities in entity_attack listener
- handle undefined arguments in MicroCombatManager.resolveAttack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e6634a808327889e8039bf60a0f5