### PR TITLE
Improve AIEngine logging and monster behavior

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -114,7 +114,7 @@ export class CharacterFactory {
                 return merc;
             case 'monster':
                 const monster = new Monster(finalConfig);
-                monster.behaviors = [new CombatBehavior()];
+                monster.behaviors = [new CombatBehavior(), new WanderBehavior()];
                 return monster;
             case 'pet':
                 const petData = PETS[config.petId] || PETS.fox;


### PR DESCRIPTION
## Summary
- add debug logs in `AIEngine`'s individual behavior loop
- provide simple fallback movement if `MovementManager` is absent
- assign wander behavior to monsters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f5ce6f408327ae85587d08a2647c