### PR TITLE
Fix manager constructors and re-enable tactics

### DIFF
--- a/src/engines/aiEngine.js
+++ b/src/engines/aiEngine.js
@@ -50,12 +50,6 @@ export class AIEngine {
                 enemies: Object.values(this.groups).filter(g => g.id !== groupId).flatMap(g => g.members)
             };
 
-            // ==========================================================
-            // ✨ 전술 시스템 임시 비활성화
-            // 기존의 activeTactic 처리 로직 전체를 주석 처리하고,
-            // 항상 개별 행동 로직을 실행합니다. 이는 전술 시스템이
-            // 안정화될 때까지 게임 진행을 보장하기 위한 임시 조치입니다.
-            /*
             let activeTactic = this.activeTactics[groupId];
 
             if (activeTactic && activeTactic.life > 0) {
@@ -74,9 +68,6 @@ export class AIEngine {
             } else {
                 this.executeIndividualBehaviors(currentContext);
             }
-            */
-            this.executeIndividualBehaviors(currentContext);
-            // ==========================================================
         }
     }
 

--- a/src/managers/itemManager.js
+++ b/src/managers/itemManager.js
@@ -1,15 +1,12 @@
 import { Item } from '../entities.js';
 
 export class ItemManager {
-    constructor(count = 0, mapManager = null, assets = null) {
+    constructor(eventManager, mapManager, assets) {
         this.items = [];
+        this.eventManager = eventManager;
         this.mapManager = mapManager;
         this.assets = assets;
         console.log("[ItemManager] Initialized");
-
-        if (count > 0 && this.mapManager && this.assets) {
-            this._spawnItems(count);
-        }
     }
 
     _spawnItems(count) {

--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -2,21 +2,11 @@ import { TRAITS } from '../data/traits.js';
 import { adjustMonsterStatsForAquarium } from '../utils/aquariumUtils.js';
 
 export class MonsterManager {
-    constructor(a = null, b = null, c = null, d = null, e = 0) {
-        // allow legacy signature (count,map,assets,ev,factory)
-        if (typeof a === 'number') {
-            this.eventManager = d;
-            this.assets = c;
-            this.factory = e;
-            this.mapManager = b;
-            this._initialCount = a;
-        } else {
-            this.eventManager = a;
-            this.assets = b;
-            this.factory = c;
-            this.mapManager = d;
-            this._initialCount = e || 0;
-        }
+    constructor(eventManager, mapManager, assets, factory) {
+        this.eventManager = eventManager;
+        this.mapManager = mapManager;
+        this.assets = assets;
+        this.factory = factory;
         this.monsters = [];
         this.traitManager = null;
         console.log("[MonsterManager] Initialized");
@@ -25,10 +15,6 @@ export class MonsterManager {
             this.eventManager.subscribe('entity_removed', (data) => {
                 this.monsters = this.monsters.filter(m => m.id !== data.victimId);
             });
-        }
-
-        if (this._initialCount > 0 && this.mapManager && this.assets && this.factory) {
-            this._spawnMonsters(this._initialCount);
         }
     }
 

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -88,6 +88,18 @@ export class UIManager {
         if (this._isInitialized) return;
         this.callbacks = callbacks || {};
         this._statUpCallback = this.callbacks.onStatUp;
+
+        // \u2728 이 부분을 추가하여 상단 메뉴 버튼을 활성화합니다.
+        document.querySelectorAll('.menu-btn[data-panel-id]').forEach(btn => {
+            btn.onclick = () => {
+                this.showPanel(btn.dataset.panelId);
+                // \uD50C\uB808\uC774\uC5B4 \uC815\uBCF4\uCC3D\uC740 \uD2B9\uC218\uD558\uAC8C showCharacterSheet\uB97C \uD638\uCD9C\uD569\uB2C8\uB2E4.
+                if (btn.dataset.panelId === 'character-sheet-panel' && this.gameState?.player) {
+                    this.showCharacterSheet(this.gameState.player);
+                }
+            };
+        });
+
         this.onEquipItem = this.callbacks.onEquipItem;
         this.onConsumableUse = this.callbacks.onConsumableUse;
         if (this.statUpButtonsContainer) {
@@ -492,6 +504,7 @@ export class UIManager {
         } else if (panelId === 'character-sheet-panel' && this.characterSheetPanel) {
             this.characterSheetPanel.classList.remove('hidden');
         }
+        if (this.gameState) this.gameState.isPaused = true;
     }
 
     hidePanel(panelId) {

--- a/src/setup/eventListeners.js
+++ b/src/setup/eventListeners.js
@@ -103,11 +103,4 @@ export function registerGameEventListeners(engine) {
         enhancementManager: managers.enhancementManager,
     });
 
-    // Top menu buttons open their corresponding panels
-    document.querySelectorAll('.menu-btn[data-panel-id]').forEach(btn => {
-        btn.addEventListener('click', () => {
-            uiManager.showPanel(btn.dataset.panelId);
-            if (gameState) gameState.isPaused = true;
-        });
-    });
 }

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -33,11 +33,8 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.fogManager = new FogManager(mapManager.width, mapManager.height);
 
     // 엔티티 및 아이템
-    // ItemManager does not currently use the event manager, so pass 0 for count
-    // and provide the mapManager and assets so that items can be spawned and
-    // rendered correctly.
-    managers.itemManager = new Managers.ItemManager(0, mapManager, assets);
-    managers.monsterManager = new Managers.MonsterManager(eventManager, assets, factory);
+    managers.itemManager = new Managers.ItemManager(eventManager, mapManager, assets);
+    managers.monsterManager = new Managers.MonsterManager(eventManager, mapManager, assets, factory);
     managers.mercenaryManager = new Managers.MercenaryManager(eventManager, assets, factory);
     managers.equipmentManager = new Managers.EquipmentManager(eventManager);
     managers.equipmentManager.setTagManager(managers.tagManager);


### PR DESCRIPTION
## Summary
- clean up constructor args in `ItemManager` and `MonsterManager`
- pass correct arguments from `managerRegistry`
- wire menu buttons directly through `UIManager`
- re-enable group tactics in `AIEngine`
- remove redundant listeners for menu buttons and pause when opening a panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685708ffbd588327adc60e7c39f32272