### PR TITLE
Fix healer wandering and XP gain

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -70,12 +70,10 @@ export class PurifierAI extends AIArchetype {
             (a.effects || []).some(e => e.tags?.includes('status_ailment'))
         );
         if (candidates.length === 0) {
-            if (self.isFriendly && !self.isPlayer && player) {
-                const t = this._getWanderPosition(self, player, allies, mapManager);
-                if (Math.hypot(t.x - self.x, t.y - self.y) > self.tileSize * 0.3) {
-                    return { type: 'move', target: t };
-                }
-            }
+            // When no ally needs purification, stay idle so that other
+            // behaviors like wandering can take over. Previously the purifier
+            // tried to follow the player directly here, which caused healers to
+            // stick too closely to the player instead of roaming nearby.
             return { type: 'idle' };
         }
 

--- a/src/setup/eventListeners.js
+++ b/src/setup/eventListeners.js
@@ -47,6 +47,15 @@ export function registerGameEventListeners(engine) {
             itemManager.addItem(corpse);
         }
     });
+
+    // Apply experience when exp_gained fires. monsterDeathWorkflow already
+    // applies the exp directly before firing this event, so it marks the event
+    // with `applied: true` to avoid double counting.
+    eventManager.subscribe('exp_gained', (data) => {
+        if (!data.applied && data.player?.stats) {
+            data.player.stats.addExp(data.exp);
+        }
+    });
     
     eventManager.subscribe('game_over', () => {
         gameState.isGameOver = true;

--- a/src/workflows.js
+++ b/src/workflows.js
@@ -16,7 +16,9 @@ export function monsterDeathWorkflow(context) {
             attacker.stats.addExp(exp);
         }
 
-        eventManager.publish('exp_gained', { player: attacker, exp });
+        // Indicate the exp has already been applied so global listeners don't
+        // apply it again.
+        eventManager.publish('exp_gained', { player: attacker, exp, applied: true });
     }
     
     // 3. (미래를 위한 구멍) "아이템 드랍!" 이벤트를 방송한다.


### PR DESCRIPTION
## Summary
- allow other behaviors to control movement when PurifierAI has no target
- grant experience on `exp_gained` events when not already applied
- mark workflow XP events as already applied to avoid duplication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68570a8621188327a400ff7c3e93c223