### PR TITLE
Refactor Engine initialization

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -15,6 +15,8 @@ export class Game {
 
         this.loader.onReady(assets => {
             this.engine = new Engine(assets);
+            // ✨ start()를 호출하기 전에 initialize()를 먼저 호출합니다.
+            this.engine.initialize();
             this.engine.start();
         });
     }

--- a/src/managers/uiManager.js
+++ b/src/managers/uiManager.js
@@ -84,8 +84,12 @@ export class UIManager {
         };
     }
 
-    init(callbacks) {
+    init(gameState, callbacks) {
         if (this._isInitialized) return;
+
+        // ✨ gameState를 즉시 저장하여 모든 UI 기능이 정상 작동하도록 합니다.
+        this.gameState = gameState;
+
         this.callbacks = callbacks || {};
         this._statUpCallback = this.callbacks.onStatUp;
 


### PR DESCRIPTION
## Summary
- rewrite `Engine` to split initialization and startup
- update `UIManager` init signature to accept `gameState`
- adjust `Game` to call `initialize` before starting engine
- restore frame debug logs and item pickup logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68570d587a8c83279ddcae9c4a3721bc