### PR TITLE
Run tests via filesystem scan

### DIFF
--- a/run-tests.mjs
+++ b/run-tests.mjs
@@ -1,6 +1,8 @@
 import { readdir } from 'fs/promises';
 
-const files = ['ai.test.js', 'eventManager.integration.test.js'];
+// Dynamically discover all test files in the tests directory.
+const files = (await readdir('./tests')).filter(f => f.endsWith('.test.js'));
+
 for (const file of files) {
     console.log(`--- Running ${file} ---`);
     await import(`./tests/${file}`);


### PR DESCRIPTION
## Summary
- discover test files dynamically when running tests
- execute all discovered tests

## Testing
- `npm test` *(fails: Cannot find module '/workspace/tile_crawler/src/managers/item-ai-manager.js')*

------
https://chatgpt.com/codex/tasks/task_e_685713070fa88327b97526cf382a1751