### PR TITLE
Implement CombatEngine

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -63,3 +63,8 @@
 
 ## 세션 14
 - `auto-patch-algorithm.md` 문서를 작성하여 Codex의 자율 업데이트 절차를 정리.
+
+## 세션 15
+- CombatEngine 도입으로 전투 관련 이벤트 처리를 전담하도록 구조 분리.
+- managerRegistry에서 CombatEngine을 초기화하고 Engine 루프에 통합.
+- eventListeners.js에서 중복되던 전투 이벤트 핸들러를 제거하여 책임을 축소.

--- a/src/engines/combatEngine.js
+++ b/src/engines/combatEngine.js
@@ -1,0 +1,70 @@
+import { Item } from '../entities.js';
+import { debugLog } from '../utils/logger.js';
+
+export class CombatEngine {
+    constructor(eventManager, managers, assets) {
+        this.eventManager = eventManager;
+        this.managers = managers;
+        this.assets = assets || {};
+
+        const { combatCalculator, vfxManager, effectManager, microCombatManager, itemManager } = managers;
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('entity_attack', data => {
+                if (!data.attacker || !data.defender) return;
+                microCombatManager.resolveAttack(data.attacker, data.defender);
+                combatCalculator.handleAttack(data);
+                if (!data.skill || !data.skill.projectile) {
+                    vfxManager.addSpriteEffect(this.assets['strike-effect'], data.defender.x, data.defender.y, {
+                        width: data.defender.width,
+                        height: data.defender.height,
+                    });
+                }
+            });
+
+            this.eventManager.subscribe('damage_calculated', data => {
+                data.defender.takeDamage(data.damage);
+                this.eventManager.publish('entity_damaged', { ...data });
+                if (data.defender.hp <= 0) {
+                    this.eventManager.publish('entity_death', { attacker: data.attacker, victim: data.defender });
+                }
+            });
+
+            this.eventManager.subscribe('entity_damaged', data => {
+                vfxManager.flashEntity(data.defender, { color: 'rgba(255, 100, 100, 0.6)' });
+                const sleepEffect = data.defender.effects.find(e => e.id === 'sleep');
+                if (sleepEffect) {
+                    sleepEffect.hitsTaken = (sleepEffect.hitsTaken || 0) + 1;
+                    if (sleepEffect.hitsTaken >= (sleepEffect.wakeUpOnHit || 1)) {
+                        effectManager.removeEffect(data.defender, sleepEffect);
+                    }
+                }
+            });
+
+            this.eventManager.subscribe('entity_death', data => {
+                vfxManager.addDeathAnimation(data.victim, 'explode');
+                if (!data.victim.isFriendly && (data.attacker.isPlayer || data.attacker.isFriendly)) {
+                    const exp = data.victim.expValue || 0;
+                    if (exp > 0) this.eventManager.publish('exp_gained', { player: data.attacker, exp });
+                }
+                if (data.victim.unitType === 'monster') {
+                    const corpse = new Item(data.victim.x, data.victim.y, data.victim.tileSize, 'corpse', this.assets.corpse);
+                    itemManager.addItem(corpse);
+                }
+            });
+
+            this.eventManager.subscribe('exp_gained', data => {
+                if (!data.applied && data.player?.stats) {
+                    data.player.stats.addExp(data.exp);
+                }
+            });
+        }
+
+        console.log('[CombatEngine] Initialized');
+        debugLog('[CombatEngine] Initialized');
+    }
+
+    update() {
+        // Reserved for future combat ticks
+    }
+}

--- a/src/setup/eventListeners.js
+++ b/src/setup/eventListeners.js
@@ -1,61 +1,9 @@
 import { disarmWorkflow, armorBreakWorkflow } from '../workflows.js';
 import { SKILLS } from '../data/skills.js';
-import { rollOnTable } from '../utils/random.js';
-import { getMonsterLootTable } from '../data/tables.js';
-import { Item } from '../entities.js';
-
 export function registerGameEventListeners(engine) {
     const { eventManager, managers, gameState, assets } = engine;
-    const { combatCalculator, vfxManager, effectManager, monsterManager, itemManager, uiManager, motionManager, equipmentManager, projectileManager } = managers;
+    const { vfxManager, uiManager, equipmentManager } = managers;
 
-    eventManager.subscribe('entity_attack', (data) => {
-        if (!data.attacker || !data.defender) return;
-        managers.microCombatManager.resolveAttack(data.attacker, data.defender);
-        combatCalculator.handleAttack(data);
-        if (!data.skill || !data.skill.projectile) {
-            vfxManager.addSpriteEffect(assets['strike-effect'], data.defender.x, data.defender.y, { width: data.defender.width, height: data.defender.height });
-        }
-    });
-
-    eventManager.subscribe('damage_calculated', (data) => {
-        data.defender.takeDamage(data.damage);
-        eventManager.publish('entity_damaged', { ...data });
-        if (data.defender.hp <= 0) {
-            eventManager.publish('entity_death', { attacker: data.attacker, victim: data.defender });
-        }
-    });
-    
-    eventManager.subscribe('entity_damaged', (data) => {
-        vfxManager.flashEntity(data.defender, {color: 'rgba(255, 100, 100, 0.6)'});
-        const sleepEffect = data.defender.effects.find(e => e.id === 'sleep');
-        if (sleepEffect) {
-            sleepEffect.hitsTaken = (sleepEffect.hitsTaken || 0) + 1;
-            if (sleepEffect.hitsTaken >= (sleepEffect.wakeUpOnHit || 1)) {
-                effectManager.removeEffect(data.defender, sleepEffect);
-            }
-        }
-    });
-
-    eventManager.subscribe('entity_death', (data) => {
-        vfxManager.addDeathAnimation(data.victim, 'explode');
-        if (!data.victim.isFriendly && (data.attacker.isPlayer || data.attacker.isFriendly)) {
-            const exp = data.victim.expValue || 0;
-            if (exp > 0) eventManager.publish('exp_gained', { player: data.attacker, exp });
-        }
-        if (data.victim.unitType === 'monster') {
-            const corpse = new Item(data.victim.x, data.victim.y, data.victim.tileSize, 'corpse', assets.corpse);
-            itemManager.addItem(corpse);
-        }
-    });
-
-    // Apply experience when exp_gained fires. monsterDeathWorkflow already
-    // applies the exp directly before firing this event, so it marks the event
-    // with `applied: true` to avoid double counting.
-    eventManager.subscribe('exp_gained', (data) => {
-        if (!data.applied && data.player?.stats) {
-            data.player.stats.addExp(data.exp);
-        }
-    });
     
     eventManager.subscribe('game_over', () => {
         gameState.isGameOver = true;

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -9,6 +9,7 @@ import { MovementManager } from '../managers/movementManager.js';
 import { FogManager } from '../managers/fogManager.js';
 import { MicroEngine } from '../micro/MicroEngine.js';
 import { MicroCombatManager } from '../micro/MicroCombatManager.js';
+import { CombatEngine } from '../engines/combatEngine.js';
 
 export function createManagers(eventManager, assets, factory, mapManager) {
     const managers = {};
@@ -65,6 +66,9 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.microEngine = new MicroEngine(eventManager);
     managers.microCombatManager = new MicroCombatManager(eventManager);
     managers.microItemAIManager = new Managers.MicroItemAIManager();
+
+    // 전투 처리를 담당하는 CombatEngine을 도입합니다.
+    managers.combatEngine = new CombatEngine(eventManager, managers, assets);
 
     // --- 여기에 로그 매니저 생성 코드를 추가합니다. ---
     managers.combatLogManager = new Managers.CombatLogManager(eventManager);


### PR DESCRIPTION
## Summary
- add a new `CombatEngine` that handles combat-related events
- integrate `CombatEngine` in the manager registry
- slim down `eventListeners.js` so combat logic lives in the new engine
- log this session in `dev-log.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68578bb5b044832792fb38f0b777339e