### PR TITLE
Implement StatEngine per auto-patch plan

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -68,3 +68,8 @@
 - CombatEngine 도입으로 전투 관련 이벤트 처리를 전담하도록 구조 분리.
 - managerRegistry에서 CombatEngine을 초기화하고 Engine 루프에 통합.
 - eventListeners.js에서 중복되던 전투 이벤트 핸들러를 제거하여 책임을 축소.
+
+## 세션 16
+- StatEngine 도입으로 경험치와 레벨업 처리를 전담.
+- managerRegistry에서 StatEngine을 초기화하고 exp_gained 이벤트를 처리하도록 함.
+- 신규 테스트 `statEngine.test.js`로 경험치 이벤트 흐름을 검증.

--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -62,6 +62,7 @@
 | `turnManager.js` | 턴 기반 전투 모드에서 행동 순서를 결정하도록 설계되었습니다. |
 | `uiManager.js` | 인벤토리와 용병 패널 등 DOM 기반 UI 요소를 관리합니다. |
 | `vfxManager.js` | 파티클 및 스프라이트 효과를 생성하여 시각 연출을 담당합니다. |
+| `../engines/statEngine.js` | 경험치와 레벨업 처리를 담당하는 전용 엔진입니다. |
 | `../engines/knockbackEngine.js` | 넉백 물리와 위치 보정을 전담하는 전용 엔진입니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |
 | `../micro/MicroTurnManager.js` | 모든 아이템의 쿨타임 감소를 전담합니다. |

--- a/src/engines/statEngine.js
+++ b/src/engines/statEngine.js
@@ -1,0 +1,20 @@
+import { debugLog } from '../utils/logger.js';
+
+export class StatEngine {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        if (this.eventManager) {
+            this.eventManager.subscribe('exp_gained', data => {
+                if (!data.applied && data.player?.stats) {
+                    data.player.stats.addExp(data.exp);
+                }
+            });
+        }
+        console.log('[StatEngine] Initialized');
+        debugLog('[StatEngine] Initialized');
+    }
+
+    update() {
+        // Reserved for future stat-related ticks
+    }
+}

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -10,6 +10,7 @@ import { FogManager } from '../managers/fogManager.js';
 import { MicroEngine } from '../micro/MicroEngine.js';
 import { MicroCombatManager } from '../micro/MicroCombatManager.js';
 import { CombatEngine } from '../engines/combatEngine.js';
+import { StatEngine } from '../engines/statEngine.js';
 
 export function createManagers(eventManager, assets, factory, mapManager) {
     const managers = {};
@@ -69,6 +70,7 @@ export function createManagers(eventManager, assets, factory, mapManager) {
 
     // 전투 처리를 담당하는 CombatEngine을 도입합니다.
     managers.combatEngine = new CombatEngine(eventManager, managers, assets);
+    managers.statEngine = new StatEngine(eventManager);
 
     // --- 여기에 로그 매니저 생성 코드를 추가합니다. ---
     managers.combatLogManager = new Managers.CombatLogManager(eventManager);

--- a/tests/statEngine.test.js
+++ b/tests/statEngine.test.js
@@ -1,0 +1,17 @@
+import { StatEngine } from '../src/engines/statEngine.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('StatEngine', () => {
+  test('exp_gained 이벤트가 경험치 추가로 이어진다', () => {
+    const eventManager = new EventManager();
+    let gained = 0;
+    const player = { stats: { addExp: (exp) => { gained += exp; } } };
+
+    new StatEngine(eventManager);
+
+    eventManager.publish('exp_gained', { player, exp: 10 });
+
+    assert.strictEqual(gained, 10);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `StatEngine` for experience handling
- register new engine in `managerRegistry`
- document the engine in manager summary
- test the new engine with `statEngine.test.js`
- log StatEngine addition in dev log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68578d5ea88c832797eb5fefbe04d0a4