### PR TITLE
Implement VFXEngine subsystem

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -78,3 +78,8 @@
 - Emotion Card 시스템 1단계 구현: Entity에 emotionSlots 추가하고 EquipmentManager가 카드 장착을 지원하도록 수정.
 - StatManager가 알파벳 상태와 카드 조합시 추가 보너스를 계산하도록 개선.
 - 샘플 아이템 `fury_p_card`를 정의하고 테스트 `emotionCard.test.js` 작성.
+
+## 세션 18
+- VFXEngine을 도입해 전투 및 MBTI 팝업 효과 처리를 전담하도록 분리.
+- managerRegistry와 Engine 루프에 VFXEngine을 통합.
+- CombatEngine과 eventListeners의 시각 효과 코드를 이동하고 테스트 `vfxEngine.test.js` 추가.

--- a/src/engine.js
+++ b/src/engine.js
@@ -80,6 +80,7 @@ export class Engine {
         const { monsterManager, mercenaryManager, petManager, itemManager, aiEngine, fogManager } = this.managers;
 
         this.managers.knockbackEngine.update();
+        this.managers.vfxEngine.update();
 
         // Player movement
         let moveX = 0, moveY = 0;
@@ -129,7 +130,7 @@ export class Engine {
         // ✨ AI 엔진을 루프의 가장 마지막에 업데이트하여 다른 시스템의 변경사항을 모두 반영하도록 합니다.
         Object.entries(this.managers).forEach(([name, manager]) => {
             if (typeof manager.update === 'function' && manager !== aiEngine) {
-                if (name === 'fogManager' || name === 'knockbackEngine' || name === 'uiManager') return;
+                if (name === 'fogManager' || name === 'knockbackEngine' || name === 'vfxEngine' || name === 'uiManager') return;
                 try {
                     manager.update(allEntities);
                 } catch (err) {

--- a/src/engines/combatEngine.js
+++ b/src/engines/combatEngine.js
@@ -7,19 +7,13 @@ export class CombatEngine {
         this.managers = managers;
         this.assets = assets || {};
 
-        const { combatCalculator, vfxManager, effectManager, microCombatManager, itemManager } = managers;
+        const { combatCalculator, effectManager, microCombatManager, itemManager } = managers;
 
         if (this.eventManager) {
             this.eventManager.subscribe('entity_attack', data => {
                 if (!data.attacker || !data.defender) return;
                 microCombatManager.resolveAttack(data.attacker, data.defender);
                 combatCalculator.handleAttack(data);
-                if (!data.skill || !data.skill.projectile) {
-                    vfxManager.addSpriteEffect(this.assets['strike-effect'], data.defender.x, data.defender.y, {
-                        width: data.defender.width,
-                        height: data.defender.height,
-                    });
-                }
             });
 
             this.eventManager.subscribe('damage_calculated', data => {
@@ -31,7 +25,6 @@ export class CombatEngine {
             });
 
             this.eventManager.subscribe('entity_damaged', data => {
-                vfxManager.flashEntity(data.defender, { color: 'rgba(255, 100, 100, 0.6)' });
                 const sleepEffect = data.defender.effects.find(e => e.id === 'sleep');
                 if (sleepEffect) {
                     sleepEffect.hitsTaken = (sleepEffect.hitsTaken || 0) + 1;
@@ -42,7 +35,6 @@ export class CombatEngine {
             });
 
             this.eventManager.subscribe('entity_death', data => {
-                vfxManager.addDeathAnimation(data.victim, 'explode');
                 if (!data.victim.isFriendly && (data.attacker.isPlayer || data.attacker.isFriendly)) {
                     const exp = data.victim.expValue || 0;
                     if (exp > 0) this.eventManager.publish('exp_gained', { player: data.attacker, exp });

--- a/src/engines/vfxEngine.js
+++ b/src/engines/vfxEngine.js
@@ -1,0 +1,57 @@
+import { debugLog } from '../utils/logger.js';
+
+export class VFXEngine {
+    constructor(eventManager, vfxManager, assets = {}) {
+        this.eventManager = eventManager;
+        this.vfxManager = vfxManager;
+        this.assets = assets;
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('entity_attack', data => {
+                if (!data.skill || !data.skill.projectile) {
+                    this.vfxManager.addSpriteEffect(
+                        this.assets['strike-effect'],
+                        data.defender.x,
+                        data.defender.y,
+                        {
+                            width: data.defender.width,
+                            height: data.defender.height,
+                        }
+                    );
+                }
+            });
+
+            this.eventManager.subscribe('skill_used', data => {
+                const { caster, skill } = data;
+                this.vfxManager.castEffect(caster, skill);
+            });
+
+            this.eventManager.subscribe('entity_damaged', data => {
+                this.vfxManager.flashEntity(data.defender, { color: 'rgba(255, 100, 100, 0.6)' });
+            });
+
+            this.eventManager.subscribe('entity_death', data => {
+                this.vfxManager.addDeathAnimation(data.victim, 'explode');
+            });
+
+            this.eventManager.subscribe('ai_mbti_trait_triggered', data => {
+                this.vfxManager.addTextPopup(data.trait, data.entity);
+            });
+
+            this.eventManager.subscribe('knockback_wall_impact', data => {
+                const centerX = data.defender.x + data.defender.width / 2;
+                const centerY = data.defender.y + data.defender.height / 2;
+                this.vfxManager.addShockwave(centerX, centerY, { duration: 20 });
+            });
+        }
+
+        console.log('[VFXEngine] Initialized');
+        debugLog('[VFXEngine] Initialized');
+    }
+
+    update() {
+        if (this.vfxManager && typeof this.vfxManager.update === 'function') {
+            this.vfxManager.update();
+        }
+    }
+}

--- a/src/setup/eventListeners.js
+++ b/src/setup/eventListeners.js
@@ -17,11 +17,6 @@ export function registerGameEventListeners(engine) {
     eventManager.subscribe('weapon_disarmed', (data) => disarmWorkflow({ ...data, ...managers }));
     eventManager.subscribe('armor_broken', (data) => armorBreakWorkflow({ ...data, ...managers }));
 
-    eventManager.subscribe('skill_used', (data) => {
-        const { caster, skill } = data;
-        vfxManager.castEffect(caster, skill);
-    });
-
     eventManager.subscribe('key_pressed', (data) => {
         if (gameState.isPaused || gameState.isGameOver) return;
         const skillIndex = parseInt(data.key) - 1;
@@ -34,10 +29,6 @@ export function registerGameEventListeners(engine) {
                 eventManager.publish('skill_used', { caster: gameState.player, skill: skillData, target: null });
             }
         }
-    });
-
-    eventManager.subscribe('ai_mbti_trait_triggered', (data) => {
-        vfxManager.addTextPopup(data.trait, data.entity);
     });
 
 

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -4,6 +4,7 @@ import { CombatCalculator } from '../combat.js';
 import { KnockbackEngine } from '../engines/knockbackEngine.js';
 import { AIEngine } from '../engines/aiEngine.js';
 import { MBTIEngine } from '../engines/mbtiEngine.js';
+import { VFXEngine } from '../engines/vfxEngine.js';
 import { PathfindingManager } from '../managers/pathfindingManager.js';
 import { MovementManager } from '../managers/movementManager.js';
 import { FogManager } from '../managers/fogManager.js';
@@ -62,6 +63,9 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.synergyManager = new Managers.SynergyManager(eventManager);
     managers.speechBubbleManager = new Managers.SpeechBubbleManager(eventManager);
     managers.petManager = new Managers.PetManager(eventManager, factory, managers.aiEngine, managers.auraManager, managers.vfxManager);
+
+    // 시각 효과 처리를 담당하는 VFXEngine을 초기화합니다.
+    managers.vfxEngine = new VFXEngine(eventManager, managers.vfxManager, assets);
 
     // 마이크로 월드
     managers.microEngine = new MicroEngine(eventManager);

--- a/tests/vfxEngine.test.js
+++ b/tests/vfxEngine.test.js
@@ -1,0 +1,17 @@
+import { VFXEngine } from '../src/engines/vfxEngine.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('VFXEngine', () => {
+  test('MBTI trait popup fires', () => {
+    const em = new EventManager();
+    const calls = [];
+    const vfxManager = { addTextPopup: (t,e)=>calls.push({t,e}) };
+    new VFXEngine(em, vfxManager, {});
+    const ent = {};
+    em.publish('ai_mbti_trait_triggered', { trait:'E', entity:ent });
+    assert.strictEqual(calls.length,1);
+    assert.strictEqual(calls[0].t,'E');
+    assert.strictEqual(calls[0].e,ent);
+  });
+});


### PR DESCRIPTION
## Summary
- create `VFXEngine` to own visual effect event handling
- shift strike and death effects out of `CombatEngine`
- route skill and MBTI popup events through `VFXEngine`
- integrate engine with manager registry and main loop
- document the addition in `dev-log`
- add basic unit test for new engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685790a060248327ac7741a9bd57bae8