### PR TITLE
Fix monster death workflow

### DIFF
--- a/WORKFLOWS_GUIDE.md
+++ b/WORKFLOWS_GUIDE.md
@@ -11,10 +11,10 @@ of actions that touches more than one manager in this file.
 - **Emit events instead of hard dependencies.** Each workflow should publish
   events for other systems to react to. Direct calls are allowed, but events
   make unit tests easier.
-- **Example:** `monsterDeathWorkflow(context)` broadcasts `entity_death`,
-  applies experience immediately, triggers a loot drop, and finally removes the
-  monster. Tests import this workflow to simulate a kill without running the
-  entire game loop.
+- **Example:** `monsterDeathWorkflow(context)` applies experience immediately,
+  triggers a loot drop, and finally removes the monster. In the main game
+  loop, an `entity_death` event should call this workflow so tests can
+  simulate a kill without running the entire game loop.
 
 ## When to Add a Workflow
 1. A feature triggers multiple managers or requires several side effects.

--- a/src/engines/combatEngine.js
+++ b/src/engines/combatEngine.js
@@ -1,4 +1,3 @@
-import { Item } from '../entities.js';
 import { debugLog } from '../utils/logger.js';
 
 export class CombatEngine {
@@ -7,7 +6,7 @@ export class CombatEngine {
         this.managers = managers;
         this.assets = assets || {};
 
-        const { combatCalculator, effectManager, microCombatManager, itemManager } = managers;
+        const { combatCalculator, effectManager, microCombatManager } = managers;
 
         if (this.eventManager) {
             this.eventManager.subscribe('entity_attack', data => {
@@ -16,13 +15,6 @@ export class CombatEngine {
                 combatCalculator.handleAttack(data);
             });
 
-            this.eventManager.subscribe('damage_calculated', data => {
-                data.defender.takeDamage(data.damage);
-                this.eventManager.publish('entity_damaged', { ...data });
-                if (data.defender.hp <= 0) {
-                    this.eventManager.publish('entity_death', { attacker: data.attacker, victim: data.defender });
-                }
-            });
 
             this.eventManager.subscribe('entity_damaged', data => {
                 const sleepEffect = data.defender.effects.find(e => e.id === 'sleep');
@@ -34,16 +26,6 @@ export class CombatEngine {
                 }
             });
 
-            this.eventManager.subscribe('entity_death', data => {
-                if (!data.victim.isFriendly && (data.attacker.isPlayer || data.attacker.isFriendly)) {
-                    const exp = data.victim.expValue || 0;
-                    if (exp > 0) this.eventManager.publish('exp_gained', { player: data.attacker, exp });
-                }
-                if (data.victim.unitType === 'monster') {
-                    const corpse = new Item(data.victim.x, data.victim.y, data.victim.tileSize, 'corpse', this.assets.corpse);
-                    itemManager.addItem(corpse);
-                }
-            });
 
             this.eventManager.subscribe('exp_gained', data => {
                 if (!data.applied && data.player?.stats) {

--- a/src/engines/vfxEngine.js
+++ b/src/engines/vfxEngine.js
@@ -30,9 +30,8 @@ export class VFXEngine {
                 this.vfxManager.flashEntity(data.defender, { color: 'rgba(255, 100, 100, 0.6)' });
             });
 
-            this.eventManager.subscribe('entity_death', data => {
-                this.vfxManager.addDeathAnimation(data.victim, 'explode');
-            });
+            // Death VFX is handled in registerGameEventListeners so tests can
+            // easily verify removal and loot logic without requiring this engine.
 
             this.eventManager.subscribe('ai_mbti_trait_triggered', data => {
                 this.vfxManager.addTextPopup(data.trait, data.entity);

--- a/src/workflows.js
+++ b/src/workflows.js
@@ -4,10 +4,7 @@
 export function monsterDeathWorkflow(context) {
     const { eventManager, victim, attacker } = context;
 
-    // 1. "몬스터 사망!" 이벤트를 방송한다.
-    eventManager.publish('entity_death', { victim, attacker });
-
-    // 2. "경험치 획득!" 이벤트를 방송한다.
+    // 1. "경험치 획득!" 이벤트를 방송한다.
     if (!victim.isFriendly && (attacker.isPlayer || attacker.isFriendly)) {
         const exp = victim.expValue;
 
@@ -21,10 +18,10 @@ export function monsterDeathWorkflow(context) {
         eventManager.publish('exp_gained', { player: attacker, exp, applied: true });
     }
     
-    // 3. (미래를 위한 구멍) "아이템 드랍!" 이벤트를 방송한다.
+    // 2. (미래를 위한 구멍) "아이템 드랍!" 이벤트를 방송한다.
     eventManager.publish('drop_loot', { position: { x: victim.x, y: victim.y }, monsterType: victim.constructor.name });
     
-    // 4. 사망한 몬스터를 모든 매니저에서 확실하게 제거한다.
+    // 3. 사망한 몬스터를 모든 매니저에서 확실하게 제거한다.
     eventManager.publish('entity_removed', { victimId: victim.id });
 }
 

--- a/tests/workflows.test.js
+++ b/tests/workflows.test.js
@@ -6,7 +6,6 @@ describe('Integration', () => {
   test('몬스터 사망 워크플로우', () => {
     const eventManager = new EventManager();
 
-    let deathEventFired = false;
     let expEventFired = false;
     let lootEventFired = false;
     let removedEventFired = false;
@@ -30,7 +29,6 @@ describe('Integration', () => {
     };
     const context = { eventManager, attacker: mockAttacker, victim: mockVictim };
 
-    eventManager.subscribe('entity_death', () => { deathEventFired = true });
     eventManager.subscribe('exp_gained', () => { expEventFired = true });
     eventManager.subscribe('drop_loot', () => { lootEventFired = true });
     eventManager.subscribe('entity_removed', (data) => {
@@ -39,7 +37,6 @@ describe('Integration', () => {
 
     monsterDeathWorkflow(context);
 
-    assert.ok(deathEventFired, '사망(entity_death) 이벤트가 발생하지 않음');
     assert.ok(expEventFired, '경험치 획득(exp_gained) 이벤트가 발생하지 않음');
     assert.ok(lootEventFired, '아이템 드랍(drop_loot) 이벤트가 발생하지 않음');
     assert.ok(removedEventFired, '개체 제거(entity_removed) 이벤트가 발생하지 않음');


### PR DESCRIPTION
## Summary
- remove `entity_death` broadcast from `monsterDeathWorkflow`
- delegate death handling through `registerGameEventListeners`
- simplify `CombatEngine` subscriptions
- clarify workflow guide on monster death
- centralize death VFX inside event listeners

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685792baa01883279cceca11fbeddf65