### PR TITLE
Add EffectEngine with event-based buff system

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -83,3 +83,8 @@
 - VFXEngine을 도입해 전투 및 MBTI 팝업 효과 처리를 전담하도록 분리.
 - managerRegistry와 Engine 루프에 VFXEngine을 통합.
 - CombatEngine과 eventListeners의 시각 효과 코드를 이동하고 테스트 `vfxEngine.test.js` 추가.
+
+## 세션 19
+- EffectEngine을 새로 도입해 버프와 디버프 적용을 이벤트 기반으로 관리하도록 구조화.
+- managerRegistry에 EffectEngine을 등록하고 엔진 루프에서 효과 갱신이 자동으로 이루어지게 개선.
+- 문서 `docs-managers-summary.md`에 엔진 설명 추가하고 테스트 `effectEngine.test.js` 작성.

--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -62,6 +62,7 @@
 | `turnManager.js` | 턴 기반 전투 모드에서 행동 순서를 결정하도록 설계되었습니다. |
 | `uiManager.js` | 인벤토리와 용병 패널 등 DOM 기반 UI 요소를 관리합니다. |
 | `vfxManager.js` | 파티클 및 스프라이트 효과를 생성하여 시각 연출을 담당합니다. |
+| `../engines/effectEngine.js` | 버프/디버프 지속 시간을 관리하고 apply/remove 이벤트를 처리합니다. |
 | `../engines/statEngine.js` | 경험치와 레벨업 처리를 담당하는 전용 엔진입니다. |
 | `../engines/knockbackEngine.js` | 넉백 물리와 위치 보정을 전담하는 전용 엔진입니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |

--- a/src/engines/effectEngine.js
+++ b/src/engines/effectEngine.js
@@ -1,0 +1,33 @@
+import { debugLog } from '../utils/logger.js';
+
+export class EffectEngine {
+    constructor(eventManager, effectManager) {
+        this.eventManager = eventManager;
+        this.effectManager = effectManager;
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('apply_effect', data => {
+                const { target, effectId, caster } = data || {};
+                if (target && effectId) {
+                    this.effectManager.addEffect(target, effectId, caster);
+                }
+            });
+
+            this.eventManager.subscribe('remove_effect', data => {
+                const { target, effect } = data || {};
+                if (target && effect) {
+                    this.effectManager.removeEffect(target, effect);
+                }
+            });
+        }
+
+        console.log('[EffectEngine] Initialized');
+        debugLog('[EffectEngine] Initialized');
+    }
+
+    update(entities) {
+        if (this.effectManager && typeof this.effectManager.update === 'function') {
+            this.effectManager.update(entities);
+        }
+    }
+}

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -5,6 +5,7 @@ import { KnockbackEngine } from '../engines/knockbackEngine.js';
 import { AIEngine } from '../engines/aiEngine.js';
 import { MBTIEngine } from '../engines/mbtiEngine.js';
 import { VFXEngine } from '../engines/vfxEngine.js';
+import { EffectEngine } from '../engines/effectEngine.js';
 import { PathfindingManager } from '../managers/pathfindingManager.js';
 import { MovementManager } from '../managers/movementManager.js';
 import { FogManager } from '../managers/fogManager.js';
@@ -66,6 +67,7 @@ export function createManagers(eventManager, assets, factory, mapManager) {
 
     // 시각 효과 처리를 담당하는 VFXEngine을 초기화합니다.
     managers.vfxEngine = new VFXEngine(eventManager, managers.vfxManager, assets);
+    managers.effectEngine = new EffectEngine(eventManager, managers.effectManager);
 
     // 마이크로 월드
     managers.microEngine = new MicroEngine(eventManager);

--- a/tests/effectEngine.test.js
+++ b/tests/effectEngine.test.js
@@ -1,0 +1,38 @@
+import { EffectEngine } from '../src/engines/effectEngine.js';
+import { EffectManager } from '../src/managers/effectManager.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('EffectEngine', () => {
+  test('apply_effect 이벤트로 효과가 추가된다', () => {
+    const em = new EventManager();
+    const effectManager = new EffectManager(em);
+    new EffectEngine(em, effectManager);
+    const target = { effects: [], stats: { recalculate: ()=>{}, increaseBaseStat: ()=>{} }, shield:0, damageBonus:0 };
+
+    em.publish('apply_effect', { target, effectId: 'strength_buff' });
+
+    assert.strictEqual(target.effects.length, 1);
+    assert.strictEqual(target.effects[0].id, 'strength_buff');
+  });
+
+  test('remove_effect 이벤트로 효과가 제거된다', () => {
+    const em = new EventManager();
+    const effectManager = new EffectManager(em);
+    new EffectEngine(em, effectManager);
+    const target = { effects: [], stats: { recalculate: ()=>{}, increaseBaseStat: ()=>{} }, shield:0, damageBonus:0 };
+    effectManager.addEffect(target, 'strength_buff');
+    const eff = target.effects[0];
+    em.publish('remove_effect', { target, effect: eff });
+    assert.strictEqual(target.effects.length, 0);
+  });
+
+  test('update가 EffectManager.update를 호출한다', () => {
+    const em = new EventManager();
+    let called = false;
+    const effectManager = { update: () => { called = true; } };
+    const engine = new EffectEngine(em, effectManager);
+    engine.update([]);
+    assert.ok(called);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `EffectEngine` to manage buffs and debuffs via events
- register `EffectEngine` in `managerRegistry`
- document the new engine in `docs-managers-summary.md`
- log the work in `dev-log`
- add unit tests for `EffectEngine`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685795b667cc8327a86eeef52c3e084f