### PR TITLE
Add TurnEngine and integrate with manager loop

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -88,3 +88,8 @@
 - EffectEngine을 새로 도입해 버프와 디버프 적용을 이벤트 기반으로 관리하도록 구조화.
 - managerRegistry에 EffectEngine을 등록하고 엔진 루프에서 효과 갱신이 자동으로 이루어지게 개선.
 - 문서 `docs-managers-summary.md`에 엔진 설명 추가하고 테스트 `effectEngine.test.js` 작성.
+
+## 세션 20
+- TurnEngine 도입으로 턴 진행 로직을 엔진화.
+- managerRegistry에서 TurnEngine을 초기화하고 Engine 루프에 컨텍스트 전달을 지원하도록 수정.
+- 새 테스트 `turnEngine.test.js`로 위임 동작을 검증.

--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -64,6 +64,7 @@
 | `vfxManager.js` | 파티클 및 스프라이트 효과를 생성하여 시각 연출을 담당합니다. |
 | `../engines/effectEngine.js` | 버프/디버프 지속 시간을 관리하고 apply/remove 이벤트를 처리합니다. |
 | `../engines/statEngine.js` | 경험치와 레벨업 처리를 담당하는 전용 엔진입니다. |
+| `../engines/turnEngine.js` | TurnManager를 감싸 전체 턴 흐름을 관리합니다. |
 | `../engines/knockbackEngine.js` | 넉백 물리와 위치 보정을 전담하는 전용 엔진입니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |
 | `../micro/MicroTurnManager.js` | 모든 아이템의 쿨타임 감소를 전담합니다. |

--- a/src/engine.js
+++ b/src/engine.js
@@ -132,7 +132,7 @@ export class Engine {
             if (typeof manager.update === 'function' && manager !== aiEngine) {
                 if (name === 'fogManager' || name === 'knockbackEngine' || name === 'vfxEngine' || name === 'uiManager') return;
                 try {
-                    manager.update(allEntities);
+                    manager.update(allEntities, context);
                 } catch (err) {
                     console.error(`Manager ${name} update error`, err);
                     this.eventManager.publish('debug', { tag: 'ERROR', message: `${name} update failed: ${err.message}` });

--- a/src/engines/turnEngine.js
+++ b/src/engines/turnEngine.js
@@ -1,0 +1,20 @@
+import { TurnManager } from '../managers/turnManager.js';
+import { debugLog } from '../utils/logger.js';
+
+export class TurnEngine {
+    constructor(eventManager, turnManager = new TurnManager()) {
+        this.eventManager = eventManager;
+        this.turnManager = turnManager;
+        console.log('[TurnEngine] Initialized');
+        debugLog('[TurnEngine] Initialized');
+    }
+
+    update(entities, context = {}) {
+        const { player = null, parasiteManager = null } = context;
+        this.turnManager.update(entities, {
+            eventManager: this.eventManager,
+            player,
+            parasiteManager,
+        });
+    }
+}

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -13,6 +13,7 @@ import { MicroEngine } from '../micro/MicroEngine.js';
 import { MicroCombatManager } from '../micro/MicroCombatManager.js';
 import { CombatEngine } from '../engines/combatEngine.js';
 import { StatEngine } from '../engines/statEngine.js';
+import { TurnEngine } from '../engines/turnEngine.js';
 
 export function createManagers(eventManager, assets, factory, mapManager) {
     const managers = {};
@@ -77,6 +78,7 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     // 전투 처리를 담당하는 CombatEngine을 도입합니다.
     managers.combatEngine = new CombatEngine(eventManager, managers, assets);
     managers.statEngine = new StatEngine(eventManager);
+    managers.turnEngine = new TurnEngine(eventManager);
 
     // --- 여기에 로그 매니저 생성 코드를 추가합니다. ---
     managers.combatLogManager = new Managers.CombatLogManager(eventManager);

--- a/tests/turnEngine.test.js
+++ b/tests/turnEngine.test.js
@@ -1,0 +1,22 @@
+import { describe, test, assert } from './helpers.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { TurnEngine } from '../src/engines/turnEngine.js';
+
+describe('TurnEngine', () => {
+  test('update가 TurnManager.update를 호출한다', () => {
+    const em = new EventManager();
+    let called = false;
+    const dummy = { update: (ents, ctx) => { if(ctx.eventManager === em) called = true; } };
+    const engine = new TurnEngine(em, dummy);
+    engine.update([], { player: null });
+    assert.ok(called);
+  });
+
+  test('프레임이 누적되면 턴 카운트가 증가한다', () => {
+    const em = new EventManager();
+    const engine = new TurnEngine(em);
+    engine.turnManager.framesPerTurn = 5;
+    for(let i=0;i<5;i++) engine.update([], {});
+    assert.strictEqual(engine.turnManager.turnCount, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `TurnEngine` wrapping `TurnManager`
- register the engine in manager registry
- pass context to all manager `update` calls
- document the engine and log session progress
- test TurnEngine behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685797186a788327a784b6eda850cc77