### PR TITLE
Add new EventEngine with test

### DIFF
--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -66,6 +66,7 @@
 | `../engines/statEngine.js` | 경험치와 레벨업 처리를 담당하는 전용 엔진입니다. |
 | `../engines/turnEngine.js` | TurnManager를 감싸 전체 턴 흐름을 관리합니다. |
 | `../engines/knockbackEngine.js` | 넉백 물리와 위치 보정을 전담하는 전용 엔진입니다. |
+| `../engines/eventEngine.js` | 지연된 이벤트를 큐에 넣어 순차적으로 발행합니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |
 | `../micro/MicroTurnManager.js` | 모든 아이템의 쿨타임 감소를 전담합니다. |
 

--- a/src/engines/eventEngine.js
+++ b/src/engines/eventEngine.js
@@ -1,0 +1,33 @@
+import { debugLog } from '../utils/logger.js';
+
+export class EventEngine {
+    constructor(eventManager) {
+        this.eventManager = eventManager;
+        this.queue = [];
+        console.log('[EventEngine] Initialized');
+        debugLog('[EventEngine] Initialized');
+    }
+
+    /**
+     * 스케줄된 이벤트를 큐에 추가합니다.
+     * @param {number} delay - 업데이트 호출 후 남은 프레임 수
+     * @param {string} name - 이벤트 이름
+     * @param {object} data - 전달할 데이터
+     */
+    schedule(delay, name, data = {}) {
+        this.queue.push({ delay, name, data });
+    }
+
+    /**
+     * 모든 대기 중인 이벤트의 카운트를 감소시키고, 준비가 되면 발행합니다.
+     */
+    update() {
+        for (let i = this.queue.length - 1; i >= 0; i--) {
+            const evt = this.queue[i];
+            if (--evt.delay <= 0) {
+                this.eventManager.publish(evt.name, evt.data);
+                this.queue.splice(i, 1);
+            }
+        }
+    }
+}

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -6,6 +6,7 @@ import { AIEngine } from '../engines/aiEngine.js';
 import { MBTIEngine } from '../engines/mbtiEngine.js';
 import { VFXEngine } from '../engines/vfxEngine.js';
 import { EffectEngine } from '../engines/effectEngine.js';
+import { EventEngine } from '../engines/eventEngine.js';
 import { PathfindingManager } from '../managers/pathfindingManager.js';
 import { MovementManager } from '../managers/movementManager.js';
 import { FogManager } from '../managers/fogManager.js';
@@ -79,6 +80,7 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.combatEngine = new CombatEngine(eventManager, managers, assets);
     managers.statEngine = new StatEngine(eventManager);
     managers.turnEngine = new TurnEngine(eventManager);
+    managers.eventEngine = new EventEngine(eventManager);
 
     // --- 여기에 로그 매니저 생성 코드를 추가합니다. ---
     managers.combatLogManager = new Managers.CombatLogManager(eventManager);

--- a/tests/eventEngine.test.js
+++ b/tests/eventEngine.test.js
@@ -1,0 +1,21 @@
+import { EventEngine } from '../src/engines/eventEngine.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('EventEngine', () => {
+  test('지연된 이벤트가 올바른 순서로 발행된다', () => {
+    const em = new EventManager();
+    const engine = new EventEngine(em);
+    const log = [];
+    em.subscribe('a', () => log.push('a'));
+    em.subscribe('b', () => log.push('b'));
+
+    engine.schedule(1, 'a');
+    engine.schedule(2, 'b');
+
+    engine.update();
+    assert.deepStrictEqual(log, ['a']);
+    engine.update();
+    assert.deepStrictEqual(log, ['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `EventEngine` for queued event publishing
- wire EventEngine into manager registry
- document EventEngine in docs summary
- add unit test for EventEngine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579983f64483279a9956eee3e1fd4f