### PR TITLE
Introduce SpriteEngine

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -93,3 +93,7 @@
 - TurnEngine 도입으로 턴 진행 로직을 엔진화.
 - managerRegistry에서 TurnEngine을 초기화하고 Engine 루프에 컨텍스트 전달을 지원하도록 수정.
 - 새 테스트 `turnEngine.test.js`로 위임 동작을 검증.
+
+## 세션 21
+- SpriteEngine 신설로 간단한 스프라이트 애니메이션을 이벤트 기반으로 관리.
+- managerRegistry와 Engine 루프에 SpriteEngine을 연결하고 테스트 `spriteEngine.test.js` 작성.

--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -67,6 +67,7 @@
 | `../engines/turnEngine.js` | TurnManager를 감싸 전체 턴 흐름을 관리합니다. |
 | `../engines/knockbackEngine.js` | 넉백 물리와 위치 보정을 전담하는 전용 엔진입니다. |
 | `../engines/eventEngine.js` | 지연된 이벤트를 큐에 넣어 순차적으로 발행합니다. |
+| `../engines/spriteEngine.js` | 다중 프레임 스프라이트 애니메이션을 관리합니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |
 | `../micro/MicroTurnManager.js` | 모든 아이템의 쿨타임 감소를 전담합니다. |
 

--- a/src/engine.js
+++ b/src/engine.js
@@ -81,6 +81,7 @@ export class Engine {
 
         this.managers.knockbackEngine.update();
         this.managers.vfxEngine.update();
+        this.managers.spriteEngine?.update();
 
         // Player movement
         let moveX = 0, moveY = 0;
@@ -130,7 +131,7 @@ export class Engine {
         // ✨ AI 엔진을 루프의 가장 마지막에 업데이트하여 다른 시스템의 변경사항을 모두 반영하도록 합니다.
         Object.entries(this.managers).forEach(([name, manager]) => {
             if (typeof manager.update === 'function' && manager !== aiEngine) {
-                if (name === 'fogManager' || name === 'knockbackEngine' || name === 'vfxEngine' || name === 'uiManager') return;
+                if (name === 'fogManager' || name === 'knockbackEngine' || name === 'vfxEngine' || name === 'spriteEngine' || name === 'uiManager') return;
                 try {
                     manager.update(allEntities, context);
                 } catch (err) {

--- a/src/engines/spriteEngine.js
+++ b/src/engines/spriteEngine.js
@@ -1,0 +1,57 @@
+import { debugLog } from '../utils/logger.js';
+
+export class SpriteEngine {
+    constructor(eventManager, vfxManager) {
+        this.eventManager = eventManager;
+        this.vfxManager = vfxManager;
+        this.animations = [];
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('play_sprite_animation', data => {
+                const { frames = [], x = 0, y = 0, frameDuration = 5, loop = false } = data || {};
+                if (frames.length === 0) return;
+                this.animations.push({
+                    frames,
+                    x,
+                    y,
+                    frameDuration,
+                    loop,
+                    currentFrame: 0,
+                    timer: frameDuration,
+                });
+            });
+
+            this.eventManager.subscribe('cancel_sprite_animation', anim => {
+                const idx = this.animations.indexOf(anim);
+                if (idx !== -1) this.animations.splice(idx, 1);
+            });
+        }
+
+        console.log('[SpriteEngine] Initialized');
+        debugLog('[SpriteEngine] Initialized');
+    }
+
+    update() {
+        if (!this.vfxManager) return;
+        for (let i = this.animations.length - 1; i >= 0; i--) {
+            const anim = this.animations[i];
+            if (anim.timer-- <= 0) {
+                anim.currentFrame++;
+                if (anim.currentFrame >= anim.frames.length) {
+                    if (anim.loop) {
+                        anim.currentFrame = 0;
+                    } else {
+                        this.animations.splice(i, 1);
+                        continue;
+                    }
+                }
+                anim.timer = anim.frameDuration;
+            }
+
+            const frameImage = anim.frames[anim.currentFrame];
+            if (frameImage) {
+                this.vfxManager.addSpriteEffect(frameImage, anim.x, anim.y);
+            }
+        }
+    }
+}

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -6,6 +6,7 @@ import { AIEngine } from '../engines/aiEngine.js';
 import { MBTIEngine } from '../engines/mbtiEngine.js';
 import { VFXEngine } from '../engines/vfxEngine.js';
 import { EffectEngine } from '../engines/effectEngine.js';
+import { SpriteEngine } from '../engines/spriteEngine.js';
 import { EventEngine } from '../engines/eventEngine.js';
 import { PathfindingManager } from '../managers/pathfindingManager.js';
 import { MovementManager } from '../managers/movementManager.js';
@@ -69,6 +70,7 @@ export function createManagers(eventManager, assets, factory, mapManager) {
 
     // 시각 효과 처리를 담당하는 VFXEngine을 초기화합니다.
     managers.vfxEngine = new VFXEngine(eventManager, managers.vfxManager, assets);
+    managers.spriteEngine = new SpriteEngine(eventManager, managers.vfxManager);
     managers.effectEngine = new EffectEngine(eventManager, managers.effectManager);
 
     // 마이크로 월드

--- a/tests/spriteEngine.test.js
+++ b/tests/spriteEngine.test.js
@@ -1,0 +1,18 @@
+import { SpriteEngine } from '../src/engines/spriteEngine.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('SpriteEngine', () => {
+  test('play_sprite_animation triggers sequential frames', () => {
+    const em = new EventManager();
+    const frames = ['a', 'b'];
+    const calls = [];
+    const vfx = { addSpriteEffect: img => calls.push(img) };
+    const engine = new SpriteEngine(em, vfx);
+    em.publish('play_sprite_animation', { frames, x:0, y:0, frameDuration:1 });
+    engine.update();
+    assert.strictEqual(calls[0], 'a');
+    engine.update();
+    assert.strictEqual(calls[1], 'b');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `SpriteEngine` to handle sprite animations
- wire the engine into `managerRegistry` and main loop
- document SpriteEngine in managers summary and log session
- add tests for SpriteEngine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579b4974788327a4bd7ae341005386