### PR TITLE
Implement ProjectileEngine

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -77,7 +77,7 @@ export class Engine {
         if (this.gameState.isPaused || this.gameState.isGameOver) return;
 
         const { player } = this.gameState;
-        const { monsterManager, mercenaryManager, petManager, itemManager, aiEngine, fogManager } = this.managers;
+        const { monsterManager, mercenaryManager, petManager, itemManager, aiEngine, fogManager, projectileEngine } = this.managers;
 
         this.managers.knockbackEngine.update();
         this.managers.vfxEngine.update();
@@ -128,10 +128,12 @@ export class Engine {
             aiEngine,
         };
 
+        projectileEngine.update(allEntities);
+
         // ✨ AI 엔진을 루프의 가장 마지막에 업데이트하여 다른 시스템의 변경사항을 모두 반영하도록 합니다.
         Object.entries(this.managers).forEach(([name, manager]) => {
             if (typeof manager.update === 'function' && manager !== aiEngine) {
-                if (name === 'fogManager' || name === 'knockbackEngine' || name === 'vfxEngine' || name === 'spriteEngine' || name === 'uiManager') return;
+                if (name === 'fogManager' || name === 'knockbackEngine' || name === 'vfxEngine' || name === 'spriteEngine' || name === 'uiManager' || name === 'projectileManager' || name === 'projectileEngine') return;
                 try {
                     manager.update(allEntities, context);
                 } catch (err) {

--- a/src/engines/projectileEngine.js
+++ b/src/engines/projectileEngine.js
@@ -1,0 +1,25 @@
+import { debugLog } from '../utils/logger.js';
+
+export class ProjectileEngine {
+    constructor(eventManager, projectileManager) {
+        this.eventManager = eventManager;
+        this.projectileManager = projectileManager;
+
+        if (this.eventManager) {
+            this.eventManager.subscribe('skill_used', ({ caster, skill, target }) => {
+                if (skill?.projectile && target) {
+                    this.projectileManager?.create(caster, target, skill);
+                }
+            });
+        }
+
+        console.log('[ProjectileEngine] Initialized');
+        debugLog('[ProjectileEngine] Initialized');
+    }
+
+    update(entities) {
+        if (this.projectileManager && typeof this.projectileManager.update === 'function') {
+            this.projectileManager.update(entities);
+        }
+    }
+}

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -16,6 +16,7 @@ import { MicroCombatManager } from '../micro/MicroCombatManager.js';
 import { CombatEngine } from '../engines/combatEngine.js';
 import { StatEngine } from '../engines/statEngine.js';
 import { TurnEngine } from '../engines/turnEngine.js';
+import { ProjectileEngine } from '../engines/projectileEngine.js';
 
 export function createManagers(eventManager, assets, factory, mapManager) {
     const managers = {};
@@ -63,6 +64,7 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.skillManager = new Managers.SkillManager(eventManager);
     managers.skillManager.setManagers(managers.effectManager, factory, managers.aiEngine, managers.monsterManager);
     managers.projectileManager = new Managers.ProjectileManager(eventManager, assets, managers.vfxManager);
+    managers.projectileEngine = new ProjectileEngine(eventManager, managers.projectileManager);
     managers.auraManager = new Managers.AuraManager(managers.effectManager, eventManager, managers.vfxManager);
     managers.synergyManager = new Managers.SynergyManager(eventManager);
     managers.speechBubbleManager = new Managers.SpeechBubbleManager(eventManager);

--- a/tests/projectileEngine.test.js
+++ b/tests/projectileEngine.test.js
@@ -1,0 +1,29 @@
+import { ProjectileEngine } from '../src/engines/projectileEngine.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('ProjectileEngine', () => {
+  test('skill_used 이벤트로 투사체가 생성된다', () => {
+    const em = new EventManager();
+    const calls = [];
+    const pm = { create: (c,t,s)=>calls.push({c,t,s}), update: ()=>{} };
+    new ProjectileEngine(em, pm);
+    const caster = {};
+    const target = {};
+    const skill = { projectile:'fireball' };
+    em.publish('skill_used', { caster, skill, target });
+    assert.strictEqual(calls.length,1);
+    assert.strictEqual(calls[0].c,caster);
+    assert.strictEqual(calls[0].t,target);
+    assert.strictEqual(calls[0].s,skill);
+  });
+
+  test('update가 ProjectileManager.update를 호출한다', () => {
+    const em = new EventManager();
+    let called = false;
+    const pm = { update: () => { called = true; } };
+    const engine = new ProjectileEngine(em, pm);
+    engine.update([]);
+    assert.ok(called);
+  });
+});


### PR DESCRIPTION
## Summary
- add `ProjectileEngine` to manage projectile creation and updates
- wire new engine through `managerRegistry`
- orchestrate updates from `Engine`
- test projectile engine behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579cc0a8f883279abb1e74622b4c2b