### PR TITLE
Add new engine modules and tests

### DIFF
--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -70,5 +70,8 @@
 | `../engines/spriteEngine.js` | 다중 프레임 스프라이트 애니메이션을 관리합니다. |
 | `../micro/MicroEngine.js` | 미시 세계 전투와 아이템 상태 갱신을 담당하는 엔진입니다. |
 | `../micro/MicroTurnManager.js` | 모든 아이템의 쿨타임 감소를 전담합니다. |
+| `../engines/skillEngine.js` | SkillManager와 연계해 스킬 사용 이벤트를 처리합니다. |
+| `../engines/movementEngine.js` | 이동 요청 이벤트를 받아 MovementManager에 위임합니다. |
+| `../engines/microTurnEngine.js` | MicroTurnManager 업데이트를 담당하는 경량 엔진입니다. |
 
 추가 매니저가 도입되면 이 목록을 계속 확장해 주세요.

--- a/src/engines/microTurnEngine.js
+++ b/src/engines/microTurnEngine.js
@@ -1,0 +1,14 @@
+import { MicroTurnManager } from '../micro/MicroTurnManager.js';
+import { debugLog } from '../utils/logger.js';
+
+export class MicroTurnEngine {
+    constructor(microTurnManager = new MicroTurnManager()) {
+        this.turnManager = microTurnManager;
+        console.log('[MicroTurnEngine] Initialized');
+        debugLog('[MicroTurnEngine] Initialized');
+    }
+
+    update(items) {
+        this.turnManager.update(items);
+    }
+}

--- a/src/engines/movementEngine.js
+++ b/src/engines/movementEngine.js
@@ -1,0 +1,19 @@
+import { debugLog } from '../utils/logger.js';
+
+export class MovementEngine {
+    constructor(eventManager, movementManager) {
+        this.eventManager = eventManager;
+        this.movementManager = movementManager;
+        if (this.eventManager) {
+            this.eventManager.subscribe('move_entity', ({ entity, target, context }) => {
+                this.movementManager?.moveEntityTowards(entity, target, context);
+            });
+        }
+        console.log('[MovementEngine] Initialized');
+        debugLog('[MovementEngine] Initialized');
+    }
+
+    update() {
+        // Reserved for future movement ticks
+    }
+}

--- a/src/engines/skillEngine.js
+++ b/src/engines/skillEngine.js
@@ -1,0 +1,21 @@
+import { debugLog } from '../utils/logger.js';
+
+export class SkillEngine {
+    constructor(eventManager, skillManager) {
+        this.eventManager = eventManager;
+        this.skillManager = skillManager;
+        if (this.eventManager) {
+            this.eventManager.subscribe('skill_used', ({ caster, skill, target }) => {
+                this.skillManager?.applySkillEffects(caster, skill, target);
+            });
+        }
+        console.log('[SkillEngine] Initialized');
+        debugLog('[SkillEngine] Initialized');
+    }
+
+    update() {
+        if (this.skillManager && typeof this.skillManager.update === 'function') {
+            this.skillManager.update();
+        }
+    }
+}

--- a/src/micro/MicroEngine.js
+++ b/src/micro/MicroEngine.js
@@ -1,14 +1,14 @@
-import { MicroTurnManager } from './MicroTurnManager.js';
 import { debugLog } from '../utils/logger.js';
+import { MicroTurnEngine } from '../engines/microTurnEngine.js';
 
 // src/micro/MicroEngine.js
 
 // MicroEngine handles the micro-world progression. It listens for combat events
 // and updates weapon experience and proficiency accordingly.
 export class MicroEngine {
-    constructor(eventManager) {
+    constructor(eventManager, microTurnEngine = null) {
         this.eventManager = eventManager;
-        this.turnManager = new MicroTurnManager();
+        this.turnEngine = microTurnEngine;
 
         if (this.eventManager) {
             this.eventManager.subscribe('attack_landed', data => this.handleAttackLanded(data));
@@ -56,8 +56,8 @@ export class MicroEngine {
     }
 
     update(allItems) {
-        // 게임 루프로부터 전달된 아이템 목록을 TurnManager에 위임한다
-        this.turnManager.update(allItems);
+        // 게임 루프로부터 전달된 아이템 목록을 MicroTurnEngine에 위임한다
+        this.turnEngine?.update(allItems);
         // Additional micro-world systems can be ticked here.
     }
 }

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -12,11 +12,14 @@ import { PathfindingManager } from '../managers/pathfindingManager.js';
 import { MovementManager } from '../managers/movementManager.js';
 import { FogManager } from '../managers/fogManager.js';
 import { MicroEngine } from '../micro/MicroEngine.js';
+import { MicroTurnEngine } from '../engines/microTurnEngine.js';
 import { MicroCombatManager } from '../micro/MicroCombatManager.js';
 import { CombatEngine } from '../engines/combatEngine.js';
 import { StatEngine } from '../engines/statEngine.js';
 import { TurnEngine } from '../engines/turnEngine.js';
 import { ProjectileEngine } from '../engines/projectileEngine.js';
+import { SkillEngine } from '../engines/skillEngine.js';
+import { MovementEngine } from '../engines/movementEngine.js';
 
 export function createManagers(eventManager, assets, factory, mapManager) {
     const managers = {};
@@ -65,6 +68,8 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.skillManager.setManagers(managers.effectManager, factory, managers.aiEngine, managers.monsterManager);
     managers.projectileManager = new Managers.ProjectileManager(eventManager, assets, managers.vfxManager);
     managers.projectileEngine = new ProjectileEngine(eventManager, managers.projectileManager);
+    managers.skillEngine = new SkillEngine(eventManager, managers.skillManager);
+    managers.movementEngine = new MovementEngine(eventManager, managers.movementManager);
     managers.auraManager = new Managers.AuraManager(managers.effectManager, eventManager, managers.vfxManager);
     managers.synergyManager = new Managers.SynergyManager(eventManager);
     managers.speechBubbleManager = new Managers.SpeechBubbleManager(eventManager);
@@ -76,7 +81,8 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.effectEngine = new EffectEngine(eventManager, managers.effectManager);
 
     // 마이크로 월드
-    managers.microEngine = new MicroEngine(eventManager);
+    managers.microTurnEngine = new MicroTurnEngine();
+    managers.microEngine = new MicroEngine(eventManager, managers.microTurnEngine);
     managers.microCombatManager = new MicroCombatManager(eventManager);
     managers.microItemAIManager = new Managers.MicroItemAIManager();
 

--- a/tests/microTurnEngine.test.js
+++ b/tests/microTurnEngine.test.js
@@ -1,0 +1,12 @@
+import { MicroTurnEngine } from '../src/engines/microTurnEngine.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('MicroTurnEngine', () => {
+  test('update가 MicroTurnManager.update를 호출한다', () => {
+    let called = false;
+    const manager = { update: () => { called = true; } };
+    const engine = new MicroTurnEngine(manager);
+    engine.update([]);
+    assert.ok(called);
+  });
+});

--- a/tests/movementEngine.test.js
+++ b/tests/movementEngine.test.js
@@ -1,0 +1,14 @@
+import { MovementEngine } from '../src/engines/movementEngine.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('MovementEngine', () => {
+  test('move_entity 이벤트로 MovementManager.moveEntityTowards 호출', () => {
+    const em = new EventManager();
+    let called = false;
+    const mm = { moveEntityTowards: () => { called = true; } };
+    new MovementEngine(em, mm);
+    em.publish('move_entity', { entity:{}, target:{}, context:{} });
+    assert.ok(called);
+  });
+});

--- a/tests/skillEngine.test.js
+++ b/tests/skillEngine.test.js
@@ -1,0 +1,23 @@
+import { SkillEngine } from '../src/engines/skillEngine.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('SkillEngine', () => {
+  test('skill_used 이벤트로 스킬 효과가 적용된다', () => {
+    const em = new EventManager();
+    let called = false;
+    const sm = { applySkillEffects: () => { called = true; } };
+    new SkillEngine(em, sm);
+    em.publish('skill_used', { caster:{}, skill:{}, target:{} });
+    assert.ok(called);
+  });
+
+  test('update가 SkillManager.update를 호출한다', () => {
+    const em = new EventManager();
+    let called = false;
+    const sm = { update: () => { called = true; } };
+    const engine = new SkillEngine(em, sm);
+    engine.update();
+    assert.ok(called);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `SkillEngine`, `MovementEngine`, and `MicroTurnEngine`
- refactor `MicroEngine` to use `MicroTurnEngine`
- register new engines in `managerRegistry`
- document new engines in `docs-managers-summary.md`
- add unit tests for the new engines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579e923a1c8327bfbb4cf6f70cc6df