### PR TITLE
Fix AI logging and weapon sprite rendering

### DIFF
--- a/src/engines/aiEngine.js
+++ b/src/engines/aiEngine.js
@@ -211,8 +211,9 @@ export class AIEngine {
 
             const { finalAction, triggeredTraits } = this.mbtiEngine.refineAction(baseAction, member, context);
             finalAction.triggeredTraits = triggeredTraits;
-            console.log(`[AIEngine] Member action:`, finalAction);
-            debugLog(`[AIEngine] Member action:`, finalAction);
+            if (finalAction.type !== 'idle') {
+                debugLog(`[AIEngine] Member action:`, finalAction);
+            }
             this.executeAction(member, finalAction, context);
         }
     }

--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -10,6 +10,7 @@ export class MonsterManager {
         this.factory = factory;
         this.monsters = [];
         this.traitManager = null;
+        this.equipmentRenderManager = null;
         console.log("[MonsterManager] Initialized");
         debugLog("[MonsterManager] Initialized");
 
@@ -40,6 +41,9 @@ export class MonsterManager {
                     image: this.assets?.monster,
                     baseStats: stats
                 });
+                if (this.equipmentRenderManager) {
+                    monster.equipmentRenderManager = this.equipmentRenderManager;
+                }
                 this.monsters.push(monster);
             }
         }

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -47,11 +47,14 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     managers.itemManager = new Managers.ItemManager(eventManager, mapManager, assets);
     managers.monsterManager = new Managers.MonsterManager(eventManager, mapManager, assets, factory);
     managers.mercenaryManager = new Managers.MercenaryManager(eventManager, assets, factory);
+    managers.equipmentRenderManager = new Managers.EquipmentRenderManager(eventManager, assets, factory);
     managers.equipmentManager = new Managers.EquipmentManager(eventManager);
     managers.equipmentManager.setTagManager(managers.tagManager);
     managers.traitManager = new Managers.TraitManager(eventManager, assets, factory);
     managers.mercenaryManager.setTraitManager(managers.traitManager);
     managers.monsterManager.setTraitManager(managers.traitManager);
+    managers.mercenaryManager.equipmentRenderManager = managers.equipmentRenderManager;
+    managers.monsterManager.equipmentRenderManager = managers.equipmentRenderManager;
 
     // 시각 및 효과
     managers.vfxManager = new Managers.VFXManager(eventManager, managers.itemManager);

--- a/src/setup/worldBuilder.js
+++ b/src/setup/worldBuilder.js
@@ -19,6 +19,9 @@ export function buildInitialWorld(managers, assets) {
         image: assets.player,
         baseStats: { strength: 5, agility: 5, endurance: 15, movement: 4 },
     });
+    if (managers.equipmentRenderManager) {
+        player.equipmentRenderManager = managers.equipmentRenderManager;
+    }
     player.ai = null;
     playerGroup.addMember(player);
     aiEngine.addMember(playerGroup.id, player);
@@ -71,6 +74,9 @@ export function buildInitialWorld(managers, assets) {
                 groupId: monsterGroup.id,
                 image: assets.monster,
             });
+            if (managers.equipmentRenderManager) {
+                monster.equipmentRenderManager = managers.equipmentRenderManager;
+            }
             monsterGroup.addMember(monster);
             aiEngine.addMember(monsterGroup.id, monster);
             monsterManager.monsters.push(monster);

--- a/tests/healerHeal.test.js
+++ b/tests/healerHeal.test.js
@@ -10,6 +10,7 @@ describe('Healing', () => {
     const factory = new CharacterFactory(assets);
     const healer = factory.create('mercenary', { x:0, y:0, tileSize:1, groupId:'g', jobId:'healer' });
     healer.ai = new HealerAI();
+    healer.properties.mbti = 'ISFJ';
     healer.mp = healer.maxMp; // 충분한 마나 확보
     const ally = factory.create('mercenary', { x:5, y:0, tileSize:1, groupId:'g', jobId:'warrior' });
     ally.hp = ally.maxHp - 5; // 부상 입힘


### PR DESCRIPTION
## Summary
- trim noisy console output in `AIEngine`
- setup `EquipmentRenderManager` in `managerRegistry`
- attach equipment renderer to player, mercenaries, and monsters
- include MBTI in healer test for stable results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857a14c3480832789983025b4e10ad7