### PR TITLE
Fix aquarium exp and tighten mercenary AI

### DIFF
--- a/src/ai/behaviors/combat.js
+++ b/src/ai/behaviors/combat.js
@@ -1,6 +1,8 @@
 import { Behavior } from './base.js';
 import { hasLineOfSight } from '../../utils/geometry.js';
 
+const ENGAGEMENT_RATIO = 0.6;
+
 export class CombatBehavior extends Behavior {
     decideAction(self, context) {
         const { player, enemies, mapManager, eventManager } = context;
@@ -35,6 +37,13 @@ export class CombatBehavior extends Behavior {
 
         self.currentTarget = nearestTarget;
         const distance = Math.hypot(nearestTarget.x - self.x, nearestTarget.y - self.y);
+
+        // 교전 시작 거리를 시야의 일부 비율로 제한하여 즉시 돌격을 방지한다
+        const engagementRange = currentVisionRange * ENGAGEMENT_RATIO;
+
+        if (distance > engagementRange && distance > self.attackRange) {
+            return { type: 'idle' };
+        }
 
         const weaponTags = self.equipment?.weapon?.tags || [];
         const isRanged = weaponTags.includes('ranged') || weaponTags.includes('bow');

--- a/src/managers/aquariumManager.js
+++ b/src/managers/aquariumManager.js
@@ -3,6 +3,8 @@
 import { TRAITS } from '../data/traits.js';
 import { EquipmentManager } from './equipmentManager.js';
 import { adjustMonsterStatsForAquarium } from '../utils/aquariumUtils.js';
+
+const DEFAULT_EXP_VALUE = 5;
 export class AquariumManager {
     constructor(eventManager, monsterManager, itemManager, mapManager, charFactory, itemFactory, vfxManager = null, traitManager = null) {
         this.eventManager = eventManager;
@@ -74,6 +76,7 @@ export class AquariumManager {
 
             const vision = opts.baseStats?.visionRange ?? this.mapManager.tileSize * 2;
             const stats = adjustMonsterStatsForAquarium({
+                expValue: opts.baseStats?.expValue ?? DEFAULT_EXP_VALUE,
                 ...(opts.baseStats || {}),
                 visionRange: vision,
             });
@@ -127,6 +130,7 @@ export class AquariumManager {
             if (pos) {
                 const vision = feature.baseStats?.visionRange ?? this.mapManager.tileSize * 2;
                 const stats = adjustMonsterStatsForAquarium({
+                    expValue: feature.baseStats?.expValue ?? DEFAULT_EXP_VALUE,
                     ...feature.baseStats,
                     visionRange: vision,
                 });

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -14,6 +14,14 @@ describe('Behavior AI', () => {
     assert.strictEqual(action.target, enemy);
   });
 
+  test('CombatBehavior idles when target is far', () => {
+    const beh = new CombatBehavior();
+    const self = { x:0, y:0, attackRange:2, visionRange:30, equipment:{}, properties:{} };
+    const enemy = { x:25, y:0, hp:10 };
+    const action = beh.decideAction(self, { enemies:[enemy], allies:[], player:{}, mapManager:mapStub });
+    assert.strictEqual(action.type, 'idle');
+  });
+
   test('HealBehavior heals wounded ally', () => {
     const beh = new HealBehavior();
     const self = { x:0, y:0, attackRange:10, mp:20, skills:['heal'], skillCooldowns:{}, properties:{ mbti:'ENFP' } };

--- a/tests/aquarium.test.js
+++ b/tests/aquarium.test.js
@@ -51,4 +51,17 @@ describe('Aquarium', () => {
         assert.strictEqual(stats.get('maxHp'), (10 + base.endurance * 5) * 2);
         assert.ok(Math.abs(stats.get('attackPower')) < 0.001);
     });
+
+    test('spawnMonsterGroup assigns default exp value', () => {
+        const eventManager = new EventManager();
+        const monsterManager = new MonsterManager(0, new AquariumMapManager(), assets, eventManager, new CharacterFactory(assets));
+        const itemManager = new ItemManager(0, monsterManager.mapManager, assets);
+        const factory = new CharacterFactory(assets);
+        const vfx = new VFXManager(eventManager);
+        const aquariumManager = new AquariumManager(eventManager, monsterManager, itemManager, monsterManager.mapManager, factory, { create(){return null;} }, vfx, null);
+        aquariumManager.spawnMonsterGroup(1);
+        assert.strictEqual(monsterManager.monsters.length, 1);
+        const monster = monsterManager.monsters[0];
+        assert.strictEqual(monster.stats.get('expValue'), 5);
+    });
 });


### PR DESCRIPTION
## Summary
- default Aquarium monster exp to 5 unless provided
- slow down combat AI by using an engagement distance ratio
- expand AI and Aquarium tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857a99469d883279bdc44b2fcc31e88