### PR TITLE
Fix ranged retreat behavior and weapon skill unlock

### DIFF
--- a/src/ai/behaviors/combat.js
+++ b/src/ai/behaviors/combat.js
@@ -52,7 +52,8 @@ export class CombatBehavior extends Behavior {
         if (mbti.includes('P')) triggeredTraits.push('P');
 
         if (isRanged) {
-            if (distance < self.attackRange * 0.5 && !mbti.includes('P')) {
+            const isTooClose = distance < self.tileSize;
+            if (distance < self.attackRange * 0.5 && !mbti.includes('P') && !isTooClose) {
                 const retreatTarget = { x: self.x - (nearestTarget.x - self.x), y: self.y - (nearestTarget.y - self.y) };
                 return { type: 'move', target: retreatTarget, triggeredTraits };
             }

--- a/src/factory.js
+++ b/src/factory.js
@@ -163,7 +163,7 @@ export class ItemFactory {
         if (baseItem.weight) item.weight = baseItem.weight;
         if (baseItem.toughness) item.toughness = baseItem.toughness;
         if (item.type === 'weapon' || item.tags.includes('weapon')) {
-            item.weaponStats = new WeaponStatManager(itemId);
+            item.weaponStats = new WeaponStatManager(itemId, item.tags);
         }
         if (baseItem.range) {
             item.range = baseItem.range;

--- a/src/micro/WeaponStatManager.js
+++ b/src/micro/WeaponStatManager.js
@@ -3,13 +3,14 @@ import { WEAPON_SKILLS } from '../data/weapon-skills.js';
 import { debugLog } from '../utils/logger.js';
 
 export class WeaponStatManager {
-    constructor(itemId) {
+    constructor(itemId, tags = []) {
         this.level = 1;
         this.exp = 0;
         this.expNeeded = 20; // 초기 필요 경험치
         this.skills = [];    // 이 무기가 현재 사용할 수 있는 스킬 목록
         this.cooldown = 0;   // 이 무기의 스킬 쿨다운
         this.ai = this._getAIByItemId(itemId);
+        this.weaponTags = tags;
 
         this._unlockSkills(); // 1레벨 스킬 즉시 해금
     }
@@ -31,9 +32,17 @@ export class WeaponStatManager {
     }
 
     _unlockSkills() {
+        const WEAPON_TYPES = ['sword', 'dagger', 'bow', 'spear', 'estoc', 'axe', 'mace', 'staff', 'scythe', 'whip', 'violin_bow'];
+
         for (const skillId in WEAPON_SKILLS) {
             const skill = WEAPON_SKILLS[skillId];
-            if (!this.skills.includes(skillId) && this.level >= (skill.requiredLevel || 1)) {
+            if (this.skills.includes(skillId) || this.level < (skill.requiredLevel || 1)) {
+                continue;
+            }
+
+            const skillWeaponTag = skill.tags.find(t => WEAPON_TYPES.includes(t));
+
+            if (skillWeaponTag && this.weaponTags.includes(skillWeaponTag)) {
                 this.skills.push(skillId);
                 console.log(`[Micro-World] 새로운 무기 스킬 [${skill.name}]을 배웠습니다!`);
                 debugLog(`[Micro-World] 새로운 무기 스킬 [${skill.name}]을 배웠습니다!`);

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -22,6 +22,22 @@ describe('Behavior AI', () => {
     assert.strictEqual(action.type, 'idle');
   });
 
+  test('Ranged unit attacks when enemy is too close to retreat', () => {
+    const beh = new CombatBehavior();
+    const self = {
+      x: 0,
+      y: 0,
+      tileSize: 1,
+      attackRange: 6,
+      visionRange: 20,
+      equipment: { weapon: { tags: ['ranged', 'bow'] } },
+      properties: { mbti: 'ISTJ' }
+    };
+    const enemy = { x: 0.5, y: 0, hp: 10 };
+    const action = beh.decideAction(self, { enemies:[enemy], allies:[], player:{}, mapManager:mapStub });
+    assert.strictEqual(action.type, 'attack');
+  });
+
   test('HealBehavior heals wounded ally', () => {
     const beh = new HealBehavior();
     const self = { x:0, y:0, attackRange:10, mp:20, skills:['heal'], skillCooldowns:{}, properties:{ mbti:'ENFP' } };

--- a/tests/weaponProficiency.test.js
+++ b/tests/weaponProficiency.test.js
@@ -19,4 +19,10 @@ describe('Micro-World: Weapon Proficiency', () => {
     sword.weaponStats.cooldown = 30;
     assert.strictEqual(sword.weaponStats.cooldown, 30);
   });
+
+  test('무기 태그에 맞는 스킬만 해금된다', () => {
+    const bowStats = new WeaponStatManager('long_bow', ['ranged', 'bow']);
+    assert.ok(bowStats.skills.includes('charge_shot'), '활 스킬 습득');
+    assert.ok(!bowStats.skills.includes('parry'), '검 스킬은 배우지 않아야 함');
+  });
 });


### PR DESCRIPTION
## Summary
- fix archer behavior to attack when an enemy is too close
- carry weapon tags to `WeaponStatManager`
- only unlock skills that match the weapon's tags
- add tests for ranged attack behavior and weapon skill unlock

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857ac062b7c8327b50fb44bac331aac