### PR TITLE
Add CoreLinkEngine and wire it up

### DIFF
--- a/src/engines/coreLinkEngine.js
+++ b/src/engines/coreLinkEngine.js
@@ -1,0 +1,63 @@
+import { debugLog } from '../utils/logger.js';
+
+export class CoreLinkEngine {
+    constructor() {
+        this.engines = new Map();
+        console.log('[CoreLinkEngine] Initialized');
+        debugLog('[CoreLinkEngine] Initialized');
+    }
+
+    /**
+     * 엔진을 등록합니다.
+     * @param {string} name - 엔진의 이름 (예: 'vfxEngine')
+     * @param {object} engineInstance - 등록할 엔진의 인스턴스
+     */
+    register(name, engineInstance) {
+        if (this.engines.has(name)) {
+            console.warn(`[CoreLinkEngine] Engine '${name}' is already registered. Overwriting.`);
+        }
+        this.engines.set(name, engineInstance);
+        debugLog(`[CoreLinkEngine] Registered: ${name}`);
+    }
+
+    /**
+     * 여러 엔진을 한 번에 등록합니다.
+     * @param {object} engineMap - { name: instance } 형태의 객체
+     */
+    registerMany(engineMap) {
+        for (const [name, instance] of Object.entries(engineMap)) {
+            this.register(name, instance);
+        }
+    }
+
+    /**
+     * 등록된 엔진을 가져옵니다.
+     * @param {string} name - 가져올 엔진의 이름
+     * @returns {object|null} - 요청한 엔진의 인스턴스
+     */
+    get(name) {
+        if (!this.engines.has(name)) {
+            debugLog(`[CoreLinkEngine] Engine '${name}' not found.`);
+            return null;
+        }
+        return this.engines.get(name);
+    }
+
+    /**
+     * 등록된 엔진 여부를 확인합니다.
+     * @param {string} name
+     * @returns {boolean}
+     */
+    has(name) {
+        return this.engines.has(name);
+    }
+
+    /**
+     * 엔진 등록을 해제합니다.
+     * @param {string} name
+     */
+    unregister(name) {
+        this.engines.delete(name);
+    }
+}
+

--- a/src/setup/managerRegistry.js
+++ b/src/setup/managerRegistry.js
@@ -20,9 +20,14 @@ import { TurnEngine } from '../engines/turnEngine.js';
 import { ProjectileEngine } from '../engines/projectileEngine.js';
 import { SkillEngine } from '../engines/skillEngine.js';
 import { MovementEngine } from '../engines/movementEngine.js';
+import { CoreLinkEngine } from '../engines/coreLinkEngine.js';
 
 export function createManagers(eventManager, assets, factory, mapManager) {
     const managers = {};
+
+    // \u2728 1. CoreLinkEngine\uC744 \uAC00\uC7A5 \uBA3C\uC800 \uC0DD\uC131\uD569\uB2C8\uB2E4.
+    const coreLinkEngine = new CoreLinkEngine();
+    managers.coreLinkEngine = coreLinkEngine;
 
     // 외부에서 전달된 기본 도구 보존
     managers.eventManager = eventManager;
@@ -105,6 +110,12 @@ export function createManagers(eventManager, assets, factory, mapManager) {
     // UI Manager는 콜백 등으로 인해 별도 처리될 수 있으므로 마지막에 추가
     managers.uiManager = new Managers.UIManager();
     managers.uiManager.mercenaryManager = managers.mercenaryManager;
+
+    // \u2728 2. \uC0DD\uC131\uB41C \uBAA8\uB4E0 \uBAA9\uB85D\uC744 coreLinkEngine\uC5D0 \uB4F1\uB85D\uD569\uB2C8\uB2E4.
+    coreLinkEngine.registerMany(managers);
+
+    // \u2728 \uAE30\uD0C0 \uC5F0\uB3D9 \uC608\uC2DC: combatEngine\uC774 coreLinkEngine\uC744 \uD65C\uC6A9
+    managers.combatEngine.coreLinkEngine = coreLinkEngine;
 
     return managers;
 }

--- a/tests/coreLinkEngine.test.js
+++ b/tests/coreLinkEngine.test.js
@@ -1,0 +1,35 @@
+import { CoreLinkEngine } from '../src/engines/coreLinkEngine.js';
+import { describe, test, assert } from './helpers.js';
+
+describe('CoreLinkEngine', () => {
+  test('register and get returns same instance', () => {
+    const engine = new CoreLinkEngine();
+    const dummy = {};
+    engine.register('dummy', dummy);
+    assert.strictEqual(engine.get('dummy'), dummy);
+  });
+
+  test('registerMany registers all engines', () => {
+    const engine = new CoreLinkEngine();
+    const a = {}, b = {};
+    engine.registerMany({ a, b });
+    assert.strictEqual(engine.get('a'), a);
+    assert.strictEqual(engine.get('b'), b);
+  });
+
+  test('get on missing engine returns null', () => {
+    const engine = new CoreLinkEngine();
+    assert.strictEqual(engine.get('missing'), null);
+  });
+
+  test('has and unregister work as expected', () => {
+    const engine = new CoreLinkEngine();
+    const obj = {};
+    engine.register('obj', obj);
+    assert.strictEqual(engine.has('obj'), true);
+    engine.unregister('obj');
+    assert.strictEqual(engine.has('obj'), false);
+    assert.strictEqual(engine.get('obj'), null);
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement CoreLinkEngine for centralized engine lookup
- register all managers via the new registry
- expose the registry to CombatEngine
- expand CoreLinkEngine API with batch registration and lookup helpers
- update tests for new methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857aedd047483279125edd6ae81bab4