### PR TITLE
Improve mercenary behavior and experience flow

### DIFF
--- a/src/ai/behaviors/combat.js
+++ b/src/ai/behaviors/combat.js
@@ -1,7 +1,8 @@
 import { Behavior } from './base.js';
 import { hasLineOfSight } from '../../utils/geometry.js';
 
-const ENGAGEMENT_RATIO = 0.6;
+// Reduce how far allies will pursue targets so they don't abandon the player.
+const ENGAGEMENT_RATIO = 0.35;
 
 export class CombatBehavior extends Behavior {
     decideAction(self, context) {
@@ -37,6 +38,14 @@ export class CombatBehavior extends Behavior {
 
         self.currentTarget = nearestTarget;
         const distance = Math.hypot(nearestTarget.x - self.x, nearestTarget.y - self.y);
+
+        // Stay near the player: if both we and the target are far away,
+        // ignore the enemy so allies don't sprint across the map.
+        const distToPlayer = Math.hypot(player.x - self.x, player.y - self.y);
+        const targetDistToPlayer = Math.hypot(nearestTarget.x - player.x, nearestTarget.y - player.y);
+        if (distToPlayer > currentVisionRange && targetDistToPlayer > currentVisionRange) {
+            return { type: 'idle' };
+        }
 
         // 교전 시작 거리를 시야의 일부 비율로 제한하여 즉시 돌격을 방지한다
         const engagementRange = currentVisionRange * ENGAGEMENT_RATIO;

--- a/src/combat.js
+++ b/src/combat.js
@@ -62,7 +62,11 @@ export class CombatCalculator {
             return;
         }
 
-        if (defendingWeapon && defendingWeapon.weaponStats?.canUseSkill('parry')) {
+        if (
+            defendingWeapon &&
+            defendingWeapon.weaponStats?.canUseSkill('parry') &&
+            Array.isArray(defendingWeapon.tags) && defendingWeapon.tags.includes('sword')
+        ) {
             const parrySkillData = WEAPON_SKILLS.parry;
             if (Math.random() < parrySkillData.procChance) {
                 this.eventManager.publish('log', {

--- a/src/factory.js
+++ b/src/factory.js
@@ -44,6 +44,13 @@ export class CharacterFactory {
         const jobStats = (type === 'mercenary' && config.jobId && JOBS[config.jobId]?.stats) ? JOBS[config.jobId].stats : {};
         Object.assign(stats, originBonus, jobStats);
 
+        // Mercenaries used to share the very large default vision range of 4 tiles,
+        // causing them to sprint across the entire map the moment they spawned.
+        // Limit their sight so they stay closer to the player unless provoked.
+        if (type === 'mercenary' && stats.visionRange === undefined) {
+            stats.visionRange = 192 * 2;
+        }
+
         // 2-3. 최종 스탯과 속성을 finalConfig에 할당합니다.
         finalConfig.stats = stats;
         finalConfig.properties = properties;

--- a/src/setup/eventListeners.js
+++ b/src/setup/eventListeners.js
@@ -35,7 +35,8 @@ export function registerGameEventListeners(engine) {
         const context = {
             eventManager,
             attacker: data.attacker,
-            victim: data.victim
+            victim: data.victim,
+            player: gameState.player
         };
         monsterDeathWorkflow(context);
     });

--- a/src/workflows.js
+++ b/src/workflows.js
@@ -2,7 +2,7 @@
 
 // === 몬스터 사망 워크플로우 ('코드 1') ===
 export function monsterDeathWorkflow(context) {
-    const { eventManager, victim, attacker } = context;
+    const { eventManager, victim, attacker, player } = context;
 
     // 1. "경험치 획득!" 이벤트를 방송한다.
     if (!victim.isFriendly && (attacker.isPlayer || attacker.isFriendly)) {
@@ -11,6 +11,10 @@ export function monsterDeathWorkflow(context) {
         // 경험치는 StatEngine을 통해 일관적으로 처리하도록 이벤트만 발행한다.
         // applied 플래그를 넘기지 않아 항상 StatEngine이 적용한다.
         eventManager.publish('exp_gained', { entity: attacker, exp });
+        // If a mercenary delivered the final blow, the player should also share the experience.
+        if (!attacker.isPlayer && player) {
+            eventManager.publish('exp_gained', { entity: player, exp: Math.floor(exp / 2) });
+        }
     }
     
     // 2. (미래를 위한 구멍) "아이템 드랍!" 이벤트를 방송한다.


### PR DESCRIPTION
## Summary
- keep mercenaries close by with reduced vision
- stop allies chasing monsters that are far away from the player
- restrict parry skill usage to sword weapons only
- share monster kill experience with the player
- provide player to `monsterDeathWorkflow`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857b3422e6c8327b172db10a6df4236