### PR TITLE
Fix missing monster exp gain

### DIFF
--- a/codex's room/dev-log.md
+++ b/codex's room/dev-log.md
@@ -97,3 +97,7 @@
 ## 세션 21
 - SpriteEngine 신설로 간단한 스프라이트 애니메이션을 이벤트 기반으로 관리.
 - managerRegistry와 Engine 루프에 SpriteEngine을 연결하고 테스트 `spriteEngine.test.js` 작성.
+
+## 세션 22
+- MonsterManager에 기본 경험치 값을 적용하여 일반 몬스터 처치 시 경험치가 0이던 문제 수정.
+- monsterManager.test.js 추가로 기본 경험치 로직을 검증.

--- a/docs-managers-summary.md
+++ b/docs-managers-summary.md
@@ -43,7 +43,7 @@
 | `layerManager.js` | 캔버스 레이어의 생성과 정렬을 통합 관리합니다. |
 | `logManager.js` | 콘솔 또는 UI에 표시되는 로그 기록을 관리합니다. |
 | `mercenaryManager.js` | 용병 생성, 고용, 상태 업데이트를 담당합니다. |
-| `monsterManager.js` | 몬스터 스폰과 제거, 업데이트 루프를 관리합니다. |
+| `monsterManager.js` | 몬스터 스폰과 제거, 업데이트 루프를 관리합니다. 기본적으로 생성되는 몬스터는 최소 경험치 값을 갖도록 보정됩니다. |
 | `motionManager.js` | 물리적 이동 애니메이션과 간단한 트위닝을 처리합니다. |
 | `movementManager.js` | 유닛의 좌표 이동과 충돌 판정을 계산합니다. |
 | `narrativeManager.js` | 스토리 플래그와 몬스터 도감 등 서사 관련 데이터를 저장합니다. |

--- a/src/managers/monsterManager.js
+++ b/src/managers/monsterManager.js
@@ -2,6 +2,8 @@ import { TRAITS } from '../data/traits.js';
 import { adjustMonsterStatsForAquarium } from '../utils/aquariumUtils.js';
 import { debugLog } from '../utils/logger.js';
 
+const DEFAULT_EXP_VALUE = 5;
+
 export class MonsterManager {
     constructor(eventManager, mapManager, assets, factory) {
         this.eventManager = eventManager;
@@ -29,7 +31,7 @@ export class MonsterManager {
         for (let i = 0; i < count; i++) {
             const pos = this.mapManager.getRandomFloorPosition();
             if (pos) {
-                let stats = {};
+                let stats = { expValue: DEFAULT_EXP_VALUE };
                 if (this.mapManager.name === 'aquarium') {
                     stats = adjustMonsterStatsForAquarium(stats);
                 }

--- a/tests/monsterManager.test.js
+++ b/tests/monsterManager.test.js
@@ -1,0 +1,20 @@
+import { MonsterManager } from '../src/managers/monsterManager.js';
+import { MapManager } from '../src/map.js';
+import { CharacterFactory } from '../src/factory.js';
+import { EventManager } from '../src/managers/eventManager.js';
+import { describe, test, assert } from './helpers.js';
+
+const assets = { monster: {} };
+
+describe('MonsterManager', () => {
+  test('_spawnMonsters 기본 경험치 적용', () => {
+    const eventManager = new EventManager();
+    const mapManager = new MapManager(1);
+    const factory = new CharacterFactory(assets);
+    const mm = new MonsterManager(eventManager, mapManager, assets, factory);
+    mm._spawnMonsters(1);
+    assert.strictEqual(mm.monsters.length, 1);
+    const monster = mm.monsters[0];
+    assert.strictEqual(monster.stats.get('expValue'), 5);
+  });
+});


### PR DESCRIPTION
## Summary
- add default exp value when MonsterManager spawns monsters
- document MonsterManager behavior in managers summary
- log patch in codex's dev log
- add test to verify default exp value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857b3a311148327b441a5a10011f0a5