### PR TITLE
Add sprite VFX for skills

### DIFF
--- a/src/data/skills.js
+++ b/src/data/skills.js
@@ -19,6 +19,8 @@ export const SKILLS = {
         manaCost: 10,
         cooldown: 90,
         tags: ['skill', 'support', 'healing', 'magic', '회복', '마법'],
+        // 시전 시 녹색 힐링 이펙트가 표시된다
+        vfxKey: 'healing-effect',
     },
     purify: {
         id: 'purify',
@@ -28,6 +30,8 @@ export const SKILLS = {
         cooldown: 90,
         tags: ['skill', 'support', 'cleanse', 'magic', '정화', '마법'],
         removeTags: ['status_ailment'],
+        // 정화 시 하얀 정화 이펙트가 재생된다
+        vfxKey: 'purify-effect',
     },
     poison_sting: {
         id: 'poison_sting',
@@ -85,6 +89,8 @@ export const SKILLS = {
         cooldown: 180,
         tags: ['skill', 'buff', 'shield', 'song', 'support', '버프', '연주'],
         effects: { target: ['shield'] },
+        // 보호막 이펙트 스프라이트 표시
+        vfxKey: 'guardian-hymn-effect',
     },
     courage_hymn: {
         id: 'courage_hymn',
@@ -94,6 +100,8 @@ export const SKILLS = {
         cooldown: 180,
         tags: ['skill', 'buff', 'attack_up', 'song', 'support', '버프', '연주'],
         effects: { target: ['bonus_damage'] },
+        // 공격력 증가 이펙트 스프라이트 표시
+        vfxKey: 'courage-hymn-effect',
     },
     hawk_eye: {
         id: 'hawk_eye',

--- a/src/engines/vfxEngine.js
+++ b/src/engines/vfxEngine.js
@@ -22,8 +22,20 @@ export class VFXEngine {
             });
 
             this.eventManager.subscribe('skill_used', data => {
-                const { caster, skill } = data;
+                const { caster, skill, target } = data;
                 this.vfxManager.castEffect(caster, skill);
+                if (skill?.vfxKey && this.assets[skill.vfxKey]) {
+                    const ent = target || caster;
+                    this.vfxManager.addSpriteEffect(
+                        this.assets[skill.vfxKey],
+                        ent.x + ent.width / 2,
+                        ent.y + ent.height / 2,
+                        {
+                            width: ent.width,
+                            height: ent.height,
+                        }
+                    );
+                }
             });
 
             this.eventManager.subscribe('entity_damaged', data => {

--- a/tests/vfxEngine.test.js
+++ b/tests/vfxEngine.test.js
@@ -14,4 +14,20 @@ describe('VFXEngine', () => {
     assert.strictEqual(calls[0].t,'E');
     assert.strictEqual(calls[0].e,ent);
   });
+
+  test('skill_used with vfxKey triggers sprite effect', () => {
+    const em = new EventManager();
+    const calls = [];
+    const vfxManager = {
+      castEffect: () => {},
+      addTextPopup: () => {},
+      addSpriteEffect: (...args) => calls.push(args)
+    };
+    const assets = { heal: 'img' };
+    new VFXEngine(em, vfxManager, assets);
+    const ent = { x: 0, y: 0, width: 10, height: 10, stats: { get: () => 1 } };
+    em.publish('skill_used', { caster: ent, target: ent, skill: { vfxKey: 'heal' } });
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0][0], assets.heal);
+  });
 });


### PR DESCRIPTION
## Summary
- show sprite VFX when skills are used
- attach vfxKey metadata to heal, purify and hymn skills
- test new VFXEngine behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857b3dce7ac8327978c3c14c755ba8a